### PR TITLE
fix: only display network currency XYM

### DIFF
--- a/__tests__/components/widgets/AccountBalanceWidget.spec.js
+++ b/__tests__/components/widgets/AccountBalanceWidget.spec.js
@@ -1,0 +1,126 @@
+import Vuex from 'vuex';
+import { createLocalVue, mount } from '@vue/test-utils'
+import AccountBalanceWidget from '@/components/widgets/AccountBalanceWidget.vue';
+import { i18n } from '@/config';
+
+jest.mock('../../../src/infrastructure/http', () => {
+  return {
+   networkCurrency: {
+      divisibility: 6,
+      mosaicId: "6BED913FA20223F8",
+      namespaceId: "E74B99BA41F4AFEE",
+      namespaceName: "symbol.xym"
+  }
+}
+});
+
+const setupStoreMount = (mosaic) => {
+  const accountModule = {
+    namespaced: true,
+    getters: {
+        OwnedMosaic:() => ({
+            loading: false,
+            error: false
+        }),
+        balanceWidget: () => ({
+          address: "TDS44G6KUHO7MODUB6E6WVJOK277QY65XCBJX5Y",
+          mosaic,
+          alias: ["N/A"],
+        })
+    },
+  };
+
+  const uiModule = {
+    namespaced: true,
+    getters: {
+      getNameByKey: state => key => i18n.getName(key),
+    },
+  };
+
+  const store = new Vuex.Store({
+    modules: {
+        account: accountModule,
+        ui:uiModule
+    },
+  });
+
+  const propsData = {
+    managerGetter: "account/OwnedMosaic",
+    dataGetter: "account/balanceWidget",
+    title: {
+      type: String,
+      default: 'accountBalanceTitle'
+    }
+  }
+
+  return mount(AccountBalanceWidget, {
+    store,
+    localVue,
+    propsData
+  });
+}
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Create AccountBalanceWidget', () => {
+  describe("computed", () => {
+    it('renders loading and error status', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount();
+
+      // Assert:
+      expect(wrapper.vm.loading).toBe(false);
+      expect(wrapper.vm.error).toBe(false);
+    })
+
+    it('renders address', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount();
+
+      // Assert:
+      expect(wrapper.vm.address).toBe('TDS44G6KUHO7MODUB6E6WVJOK277QY65XCBJX5Y');
+    })
+
+    it('renders mosaicName', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount();
+
+      // Assert:
+      expect(wrapper.vm.mosaicName).toBe('xym');
+    })
+
+    it('renders xym amount', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount({
+        amount: "1,000.000000",
+        mosaicAliasNames: ["symbol.xym"],
+        mosaicId: "6BED913FA20223F8"
+      });
+
+      // Assert:
+      expect(wrapper.vm.balance).toBe('1,000.000000');
+    })
+
+    it('renders 0 xym if mosaic is not native currency', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount({
+        amount: "1,000.000000",
+        mosaicAliasNames: ["cat.coin"],
+        mosaicId: "FFFFFFFFFFFFFFFF"
+      });
+
+      // Assert:
+      expect(wrapper.vm.balance).toBe('0');
+    })
+
+    it('renders 0 XYM amount when mosaic is empty', () => {
+      // Arrange + Act:
+      const wrapper = setupStoreMount();
+
+      // Assert:
+      expect(wrapper.vm.balance).toBe('0');
+    })
+  })
+
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,5 +16,9 @@ module.exports = {
 		'**/__tests__/**/*.spec.js'
 	],
 
-	transformIgnorePatterns: ['/node_modules']
+	transformIgnorePatterns: ['/node_modules'],
+
+	moduleNameMapper: {
+		'^@/(.*)$': '<rootDir>/src/$1'
+	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@vue/cli-plugin-unit-jest": "^4.4.4",
         "@vue/cli-service": "^4.5.15",
         "@vue/eslint-config-standard": "^4.0.0",
+        "@vue/test-utils": "^1.3.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.0.1",
         "cypress": "^3.8.3",
@@ -3872,6 +3873,21 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+      "integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
+      "dev": true,
+      "dependencies": {
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
+      },
+      "peerDependencies": {
+        "vue": "2.x",
+        "vue-template-compiler": "^2.x"
       }
     },
     "node_modules/@vue/web-component-wrapper": {
@@ -9249,6 +9265,12 @@
       "dependencies": {
         "utila": "~0.4"
       }
+    },
+    "node_modules/dom-event-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "0.1.1",
@@ -29879,6 +29901,17 @@
       "integrity": "sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==",
       "dev": true
     },
+    "@vue/test-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+      "integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
+      "dev": true,
+      "requires": {
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
+      }
+    },
     "@vue/web-component-wrapper": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.2.0.tgz",
@@ -34451,6 +34484,12 @@
       "requires": {
         "utila": "~0.4"
       }
+    },
+    "dom-event-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@vue/cli-plugin-unit-jest": "^4.4.4",
     "@vue/cli-service": "^4.5.15",
     "@vue/eslint-config-standard": "^4.0.0",
+    "@vue/test-utils": "^1.3.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
     "cypress": "^3.8.3",

--- a/src/components/widgets/AccountBalanceWidget.vue
+++ b/src/components/widgets/AccountBalanceWidget.vue
@@ -75,7 +75,11 @@ export default {
 		},
 
 		balance() {
-			return this.data.mosaic?.amount || '0';
+			// Only display network Currency
+			if (this.data.mosaic && http.networkCurrency.mosaicId === this.data.mosaic.mosaicId)
+				return this.data.mosaic.amount;
+
+			return '0';
 		},
 
 		address() {
@@ -89,16 +93,8 @@ export default {
 		},
 
 		mosaicName() {
-			const mosaicAlias = this.data.mosaic?.mosaicAliasNames[0];
-
-			if (mosaicAlias) {
-				const mosaicNamespaces = mosaicAlias.split('.');
-				const mosaicLastSubnamespace = mosaicNamespaces.pop();
-
-				return mosaicLastSubnamespace;
-			}
-
-			return this.data.mosaic?.mosaicId || http.networkCurrency.namespaceName.split('.').pop();
+			// Only display for network currency
+			return http.networkCurrency.namespaceName.split('.').pop();
 		},
 
 		loading() {


### PR DESCRIPTION
### Current behavior
- Owned mosaics will always sort XYM to the top, the `Account balance widget` will always display the first mosaic from the owned mosaics.

### What was the issue?
- If owned mosaics don't include XYM, the `Account Balance Widget` will be showing other mosaics. Which is confuses users.

### What's the fix?
- `Account Balance Widget` will only display in XYM.
- It will show 0 XYM if owned mosaics don't include XYM.
- Added Unit test.
- Test case
```
If the account has non-mosaic, it should display XYM::0
visit address TA2CXCBJH44ZS4Z3KCVG3KJHBP4FCW3U7B4OWJA

If the account has mosaics with XYM, it should display XYM with the amount.
visit address TBFKFNFAYN3WKQDG6QZMKCMS6K5QMVYQKIYL5UA

If the account has mosaics and is without XYM, it should display XYM::0
visit address TC7FDHJZ53SK5OFUIL2C6X25KQYBXHBCCWCSJGA
```


