### PR TITLE
[explorer] fix: filter rich list

### DIFF
--- a/src/config/filters.js
+++ b/src/config/filters.js
@@ -1,5 +1,4 @@
 import Constants from '../config/constants';
-import http from '../infrastructure/http';
 import {
 	TransactionType,
 	TransactionGroup,
@@ -192,7 +191,7 @@ export const account = [
 		icon: 'mdi-cash',
 		value: {
 			orderBy: AccountOrderBy.Balance,
-			mosaicId: http.networkCurrency.mosaicId
+			mosaicId: ''
 		}
 	}
 ];

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -98,14 +98,14 @@ class AccountService {
 		const searchCriteria = {
 			pageNumber,
 			pageSize,
-			order: Order.Desc
+			order: Order.Desc,
+			...filterValue
 		};
 
-		// Prevent new MosaicId throw error if mosaicId is undefined
-		if (filterValue.mosaicId) {
+		// set default network mosaic id
+		if ('' === filterValue.mosaicId) {
 			Object.assign(searchCriteria, {
-				...filterValue,
-				mosaicId: new MosaicId(filterValue.mosaicId)
+				mosaicId: new MosaicId(http.networkCurrency.mosaicId)
 			});
 		}
 


### PR DESCRIPTION
## What was the issue?
- `filters.js` loaded before the app requested the network to collect mosaic Id, so it caused `http.networkCurrency.mosaicId` to return undefined.
- it affected accounts pages `rich` list not working.

## What's the fix?
- let mosaicId to an empty value, if the value is empty, will assign a network mosaic id.

PS: I don't think this is a good solution, but still finding a way to load dynamic mosaic id into `filters.js`