### PR TITLE
[explorer] task: rename Nemesis to Genesis

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -210,7 +210,7 @@ class Constants {
 
 	static BlockType = {
 		[BlockType.ImportanceBlock]: 'Importance Block',
-		[BlockType.NemesisBlock]: 'Nemesis Block',
+		[BlockType.NemesisBlock]: 'Genesis Block',
 		[BlockType.NormalBlock]: 'Normal Block'
 	}
 


### PR DESCRIPTION
## What was the issue?
- `Nemesis` name was not a standard name for general blockchain, we rename it.

## What's the fix?
- rename `Nemesis` --> `Genesis`