### PR TITLE
[explorer] fix: ctrl+click issue on table list

### DIFF
--- a/src/components/tables/TableListView.vue
+++ b/src/components/tables/TableListView.vue
@@ -56,7 +56,6 @@
 								<div
 									v-if="isKeyClickable(itemKey) && getItemHref(itemKey, item)"
 									@click.stop
-									@click.prevent
 								>
 									<router-link
 										:to="getItemHref(itemKey, item)"


### PR DESCRIPTION
## What was the issue?
- some of the fields in the table listing are not able to open a new tab with `ctrl+click`

## What's the fix?
- found out that is a `@click.prevent` in that div, causing this issue.
- It was used for `onRowClick`, but now we have disabled it, so we are safe to remove it. 