### PR TITLE
[explorer] fix: remove address field in voting key table

### DIFF
--- a/__tests__/infrastructure/AccountService.spec.js
+++ b/__tests__/infrastructure/AccountService.spec.js
@@ -35,7 +35,7 @@ describe('Account Service', () => {
 			const mockAccountAlias = [{
 				address: account.address.plain(),
 				names: [{
-					name: 'alias',
+					name: 'alias'
 				}]
 			}];
 
@@ -50,10 +50,25 @@ describe('Account Service', () => {
 
 			// Assert:
 			expect(accountInfo.address).toEqual(account.address.plain());
-			expect(accountInfo.votingList[0].epochInfo.epochStatus).toEqual('Current');
-			expect(accountInfo.votingList[1].epochInfo.epochStatus).toEqual('Future');
-			expect(accountInfo.votingList[2].epochInfo.epochStatus).toEqual('Expired');
 			expect(accountInfo.accountAliasNames).toEqual(['alias']);
+
+			const exceptedVotingInfo = [{
+				...mockAccountInfo.supplementalPublicKeys.voting[1],
+				epochStatus: 'Current'
+			}, {
+				...mockAccountInfo.supplementalPublicKeys.voting[2],
+				epochStatus: 'Future'
+			}, {
+				...mockAccountInfo.supplementalPublicKeys.voting[0],
+				epochStatus: 'Expired'
+			}];
+
+			accountInfo.votingList.forEach((voting, index) => {
+				expect(voting.epochInfo.epochStart).toEqual(exceptedVotingInfo[index].startEpoch);
+				expect(voting.epochInfo.epochEnd).toEqual(exceptedVotingInfo[index].endEpoch);
+				expect(voting.epochInfo.epochStatus).toEqual(exceptedVotingInfo[index].epochStatus);
+				expect(voting.publicKey).toEqual(exceptedVotingInfo[index].publicKey);
+			});
 		});
 	});
 

--- a/src/config/pages/account-detail.json
+++ b/src/config/pages/account-detail.json
@@ -138,7 +138,6 @@
 				"hideOnError": true,
 				"hideDependOnGetter": "account/info",
 				"fields": [
-					"address",
 					"publicKey",
 					"epochInfo"
 				]

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -185,7 +185,6 @@ class AccountService {
 						epochEnd: voting.endEpoch,
 						epochStatus: getVotingEpochStatus(voting.startEpoch, voting.endEpoch)
 					},
-					address: helper.publicKeyToAddress(voting.publicKey),
 					publicKey: voting.publicKey
 
 				})).sort((a, b) => {


### PR DESCRIPTION
## What was the issue?
- voting key table showing the address, does not really make sense for the user because it's just a key rather than an "address"

## What's the fix?
- remove the address field out of the voting key table