### PR TITLE
[explorer] perf: reduce block request to obtain timestamp

### DIFF
--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -208,7 +208,7 @@ const TestHelper = {
 	 * @param {number} blockHeight block height.
 	 * @returns {object} transaction.
 	 */
-	mockTransaction: blockHeight => {
+	mockTransaction: ({height, timestamp}) => {
 		return {
 			deadline: {
 				adjustedValue: 8266897456
@@ -217,7 +217,14 @@ const TestHelper = {
 			type: 16724,
 			networkType: NetworkType.TEST_NET,
 			version: 1,
-			transactionInfo: new TransactionInfo(UInt64.fromUint(blockHeight), 1, 1, generateRandomHash()),
+			transactionInfo: {
+				index: 1,
+				id: 1,
+				height,
+				timestamp,
+				feeMultiplier: 10,
+				hash: generateRandomHash()
+			},
 			payloadSize: 176,
 			signature: generateRandomHash(64),
 			signer: {

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -1,14 +1,8 @@
-import { TransactionService, BlockService} from '../../src/infrastructure';
+import { TransactionService } from '../../src/infrastructure';
 import TestHelper from '../TestHelper';
 import { restore, stub } from 'sinon';
 
 describe('Transaction Service', () => {
-	let getBlockInfo = {};
-
-	beforeEach(() => {
-		getBlockInfo = stub(BlockService, 'getBlockInfo');
-	});
-
 	afterEach(restore);
 
 	describe('getTransactionInfo should', () => {
@@ -21,14 +15,14 @@ describe('Transaction Service', () => {
 				}
 			};
 
-			const mockTransactionEffectiveFee = '0.019536';
+			const mockTransactionEffectiveFee = '0.001760';
 
 			const mockBlockInfo = {
 				height: 198327,
-				timestamp: '1646063763'
+				timestamp: 1646063763
 			};
 
-			const mockTransferTransaction = TestHelper.mockTransaction(mockBlockInfo.height);
+			const mockTransferTransaction = TestHelper.mockTransaction(mockBlockInfo);
 
 			const mockCreateTransactionFromSDK = {
 				...mockTransferTransaction,
@@ -59,11 +53,6 @@ describe('Transaction Service', () => {
 
 			const getTransaction = stub(TransactionService, 'getTransaction');
 			getTransaction.returns(Promise.resolve(mockTransferTransaction));
-
-			const getTransactionEffectiveFee = stub(TransactionService, 'getTransactionEffectiveFee');
-			getTransactionEffectiveFee.returns(Promise.resolve(mockTransactionEffectiveFee));
-
-			getBlockInfo.returns(Promise.resolve(mockBlockInfo));
 
 			const createTransactionFromSDK = stub(TransactionService, 'createTransactionFromSDK');
 			createTransactionFromSDK.returns(Promise.resolve(mockCreateTransactionFromSDK));
@@ -99,20 +88,18 @@ describe('Transaction Service', () => {
 
 			const mockBlockInfo = {
 				height: 198327,
-				timestamp: '1646063763'
+				timestamp: 1646063763
 			};
 
 			const mockSearchTransactions = {
 				...pageInfo,
 				data: [
-					TestHelper.mockTransaction(mockBlockInfo.height)
+					TestHelper.mockTransaction(mockBlockInfo)
 				]
 			};
 
 			const searchTransactions = stub(TransactionService, 'searchTransactions');
 			searchTransactions.returns(Promise.resolve(mockSearchTransactions));
-
-			getBlockInfo.returns(Promise.resolve(mockBlockInfo));
 
 			// Act:
 			const transactionList = await TransactionService.getTransactionList(pageInfo, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "merkletreejs": "^0.2.31",
         "moment-timezone": "^0.5.28",
         "nem-sdk": "^1.6.8",
-        "symbol-sdk": "^2.0.0",
+        "symbol-sdk": "^2.0.1",
         "symbol-statistics-service-typescript-fetch-client": "^1.1.5",
         "url-parse": "^1.5.10",
         "vue": "^2.6.11",
@@ -26310,9 +26310,9 @@
       "integrity": "sha512-Md3/wkYLWTeJ/o99kXajW5dDs7Ok7AWfGRGDThb2bpC53KVxwnMl2ho/KUPT2Y+CeuIB62+Hgp9NtJLvgXYzHw=="
     },
     "node_modules/symbol-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.0.tgz",
-      "integrity": "sha512-ps8RwI9roBMem7kHxobVs4ZEruGTJX/6dqAlbW/9Z9weSjYihVHjgjGXWYB9FAUAGxbxeezwItmgFcgakD6pNw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.1.tgz",
+      "integrity": "sha512-0yMImFQIMWS5uMKh4jD1ZjdIV1JqFCweggYdnDhZHYjJIgnfBXFjE9yXEwkbScIKTuuOmtma/x7y36aCaq7h5w==",
       "dependencies": {
         "@js-joda/core": "^3.2.0",
         "catbuffer-typescript": "^1.0.1",
@@ -50403,9 +50403,9 @@
       "integrity": "sha512-Md3/wkYLWTeJ/o99kXajW5dDs7Ok7AWfGRGDThb2bpC53KVxwnMl2ho/KUPT2Y+CeuIB62+Hgp9NtJLvgXYzHw=="
     },
     "symbol-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.0.tgz",
-      "integrity": "sha512-ps8RwI9roBMem7kHxobVs4ZEruGTJX/6dqAlbW/9Z9weSjYihVHjgjGXWYB9FAUAGxbxeezwItmgFcgakD6pNw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.1.tgz",
+      "integrity": "sha512-0yMImFQIMWS5uMKh4jD1ZjdIV1JqFCweggYdnDhZHYjJIgnfBXFjE9yXEwkbScIKTuuOmtma/x7y36aCaq7h5w==",
       "requires": {
         "@js-joda/core": "^3.2.0",
         "catbuffer-typescript": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "merkletreejs": "^0.2.31",
     "moment-timezone": "^0.5.28",
     "nem-sdk": "^1.6.8",
-    "symbol-sdk": "^2.0.0",
+    "symbol-sdk": "^2.0.1",
     "symbol-statistics-service-typescript-fetch-client": "^1.1.5",
     "url-parse": "^1.5.10",
     "vue": "^2.6.11",

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -249,15 +249,12 @@ class AccountService {
 			};
 		}
 
-		const blockHeight = [...new Set(accountTransactions.data.map(data => data.transactionInfo.height))];
-
-		const blockInfos = await Promise.all(blockHeight.map(height => BlockService.getBlockInfo(height)));
 
 		return {
 			...accountTransactions,
 			data: accountTransactions.data.map(({ deadline, ...accountTransaction }) => ({
 				...accountTransaction,
-				timestamp: blockInfos.find(block => block.height === accountTransaction.transactionInfo.height).timestamp,
+				timestamp: accountTransaction.transactionInfo.timestamp,
 				blockHeight: accountTransaction.transactionInfo.height,
 				transactionHash: accountTransaction.transactionInfo.hash,
 				transactionType: accountTransaction.type === TransactionType.TRANSFER


### PR DESCRIPTION
## What was the issue?
- Every transaction information called extra request from block endpoint to obtain timestamp.

## What's the fix?
- updated SDK to 2.0.1
- removed extra requests to obtain block timestamp and transaction effectiveFee.