### PR TITLE
[explorer] bug: fix display mosaic amount issue

### DIFF
--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -1,5 +1,12 @@
+import TestHelper from './TestHelper';
 import Helper from '../src/helper';
 import { register, unregister } from 'timezone-mock';
+import { MosaicService, NamespaceService } from '../src/infrastructure';
+import http from '../src/infrastructure/http';
+import { stub, restore } from 'sinon';
+import { Mosaic, MosaicId, UInt64, NamespaceId } from 'symbol-sdk';
+
+const mockTestMosaicHex = '6B2E9EAF2632AEC8';
 
 describe('Helper', () => {
 	describe('hslToRgb should', () => {
@@ -9,10 +16,10 @@ describe('Helper', () => {
 			const saturation = 0.9;
 			const lightness = 0.8;
 
-			//Act:
+			// Act:
 			const rgb = Helper.hslToRgb(hue, saturation, lightness);
 
-			//Assert:
+			// Assert:
 			expect(rgb).toEqual({R: 215, G: 158, B: 250});
 		});
 	});
@@ -56,6 +63,121 @@ describe('Helper', () => {
 
 			// Assert:
 			expect(date).toEqual(expectedDateTime.local);
+		});
+	});
+
+	describe('mosaicsFieldObjectBuilder should', () => {
+		beforeEach(() => {
+			stub(MosaicService, 'getMosaics').resolves(Promise.resolve([
+				TestHelper.mockMosaicInfo('6B2E9EAF2632AEC8', 'TC46AZWUIZYZ2WVGLVEZYNZHSIFAD3AFDPUJMEA', 10, 0)
+			]));
+
+			stub(NamespaceService, 'getMosaicsNames').resolves(Promise.resolve([{
+				mosaicId: '6B2E9EAF2632AEC8',
+				names: []
+			}]));
+		});
+
+		afterEach(restore);
+
+		it('returns basic mosaic object', async () => {
+			// Arrange:
+			const mockMosaics = [
+				new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1)),
+				new Mosaic(new MosaicId(mockTestMosaicHex), UInt64.fromUint(4))
+			];
+
+			// Act:
+			const result = await Helper.mosaicsFieldObjectBuilder(mockMosaics);
+
+			// Assert:
+			expect(result).toStrictEqual([
+				{
+					amount: '0.000001',
+					id: new MosaicId(http.networkCurrency.mosaicId).id,
+					mosaicAliasName: http.networkCurrency.namespaceName,
+					mosaicId: http.networkCurrency.mosaicId,
+					rawAmount: UInt64.fromUint(1)
+				},
+				{
+					id: new MosaicId(mockTestMosaicHex).id,
+					amount: '4',
+					rawAmount: UInt64.fromUint(4),
+					mosaicId: mockTestMosaicHex,
+					mosaicAliasName: ['N/A']
+				}
+			]);
+		});
+
+		it('returns mosaics object with total amount when mosaic id is same', async () => {
+			// Arrange:
+			const mockMosaics = [
+				new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1)),
+				new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(2)),
+				new Mosaic(new MosaicId(mockTestMosaicHex), UInt64.fromUint(4))
+			];
+
+			// Act:
+			const result = await Helper.mosaicsFieldObjectBuilder(mockMosaics);
+
+			// Assert:
+			expect(result).toStrictEqual([
+				{
+					id: new MosaicId(http.networkCurrency.mosaicId).id,
+					amount: '0.000003',
+					mosaicAliasName: http.networkCurrency.namespaceName,
+					mosaicId: http.networkCurrency.mosaicId,
+					rawAmount: UInt64.fromUint(3)
+				},
+				{
+					id: new MosaicId(mockTestMosaicHex).id,
+					amount: '4',
+					rawAmount: UInt64.fromUint(4),
+					mosaicId: mockTestMosaicHex,
+					mosaicAliasName: ['N/A']
+				}
+			]);
+		});
+	});
+
+	describe('resolveMosaicId should', () => {
+		it('returns id given MosaicId', async () => {
+			// Arrange:
+			const mockMosaicId = new MosaicId(mockTestMosaicHex);
+
+			// Act:
+			const result = await Helper.resolveMosaicId(mockMosaicId);
+
+			// Assert:
+			expect(result).toStrictEqual(mockMosaicId.id);
+		});
+
+		it('returns network mosaic id given network NamespaceId', async () => {
+			// Arrange:
+			const mockNamespaceId = new NamespaceId(http.networkCurrency.namespaceName);
+
+			// Act:
+			const result = await Helper.resolveMosaicId(mockNamespaceId);
+
+			// Assert:
+			expect(result).toStrictEqual(new MosaicId(http.networkCurrency.mosaicId).id);
+		});
+	});
+
+	describe('getNetworkCurrencyBalance should', () => {
+		it('returns network currency balance', async () => {
+			// Arrange:
+			const mockMosaics = [
+				new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1)),
+				new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(2)),
+				new Mosaic(new MosaicId(mockTestMosaicHex), UInt64.fromUint(4))
+			];
+
+			// Act:
+			const result = await Helper.getNetworkCurrencyBalance(mockMosaics);
+
+			// Assert:
+			expect(result).toStrictEqual('0.000003');
 		});
 	});
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -162,7 +162,7 @@ describe('Helper', () => {
 			]);
 		});
 
-		it('returns empty array when mosaics not exist', async () => {
+		it('returns empty array when mosaics does not exist', async () => {
 			// Arrange:
 			const mockMosaics = [];
 
@@ -170,7 +170,7 @@ describe('Helper', () => {
 			const result = await Helper.mosaicsFieldObjectBuilder(mockMosaics);
 
 			// Assert:
-			expect(result).toStrictEqual(mockMosaics);
+			expect(result).toStrictEqual([]);
 		});
 	});
 
@@ -236,7 +236,7 @@ describe('Helper', () => {
 			expect(result).toStrictEqual('0.000003');
 		});
 
-		it('returns unavailable when network currency not exist', async () => {
+		it('returns unavailable when network currency does not exist', async () => {
 			// Arrange:
 			const mockMosaics = [
 				new Mosaic(new MosaicId(mockTestMosaic.idHex), UInt64.fromUint(4))

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -162,7 +162,7 @@ describe('Helper', () => {
 			]);
 		});
 
-		it('returns empty array when mosaics does not exist', async () => {
+		it('returns empty array when mosaics do not exist', async () => {
 			// Arrange:
 			const mockMosaics = [];
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -234,7 +234,10 @@ class helper {
 	 * @returns {string} relativeAmount in string
 	 */
 	static formatMosaicAmountWithDivisibility = (amount, divisibility) => {
-		let relativeAmount = 0 !== divisibility ? amount / Math.pow(10, divisibility) : amount.compact();
+		if ('number' !== typeof amount)
+			throw new Error('amount must be a number');
+
+		let relativeAmount = amount / Math.pow(10, divisibility);
 
 		return relativeAmount.toLocaleString('en-US', { minimumFractionDigits: divisibility });
 	}
@@ -555,11 +558,15 @@ class helper {
 
 			const sumAmount = mosaics.reduce((acc, cur) => acc + Number(cur.amount.toString()), 0);
 
+			const mosaicField = {
+				...mosaics[0],
+				rawAmount: UInt64.fromUint(sumAmount),
+				mosaicId: mosaics[0].id.toHex()
+			};
+
 			if (idHex === http.networkCurrency.mosaicId) {
 				mosaicsFieldObject.push({
-					...mosaics[0],
-					rawAmount: UInt64.fromUint(sumAmount),
-					mosaicId: mosaics[0].id.toHex(),
+					...mosaicField,
 					amount: this.formatMosaicAmountWithDivisibility(sumAmount, http.networkCurrency.divisibility),
 					mosaicAliasName: http.networkCurrency.namespaceName
 				});
@@ -567,10 +574,8 @@ class helper {
 				const { divisibility } = mosaicInfos.find(info => info.mosaicId === mosaics[0].id.toHex());
 
 				mosaicsFieldObject.push({
-					...mosaics[0],
-					rawAmount: mosaics[0].amount,
-					mosaicId: mosaics[0].id.toHex(),
-					amount: helper.formatMosaicAmountWithDivisibility(mosaics[0].amount, divisibility),
+					...mosaicField,
+					amount: helper.formatMosaicAmountWithDivisibility(sumAmount, divisibility),
 					mosaicAliasName: MosaicService.extractMosaicNamespace({ mosaicId: mosaics[0].id.toHex() }, mosaicNames)
 				});
 			}

--- a/src/helper.js
+++ b/src/helper.js
@@ -551,17 +551,17 @@ class helper {
 		return uniqueMosaicIds.map(idHex => {
 			const mosaics = resolvedMosaics.filter(mosaic => mosaic.id.toHex() === idHex);
 
-			const sumAmount = mosaics.reduce((acc, cur) => acc + Number(cur.amount.toString()), 0);
+			const sumAmount = mosaics.reduce((acc, cur) => acc + BigInt(cur.amount.toString()), BigInt(0));
 
 			const mosaicField = {
-				rawAmount: UInt64.fromUint(sumAmount),
+				rawAmount: UInt64.fromNumericString(sumAmount.toString()),
 				mosaicId: mosaics[0].id.toHex()
 			};
 
 			if (idHex === http.networkCurrency.mosaicId) {
 				return {
 					...mosaicField,
-					amount: this.formatMosaicAmountWithDivisibility(sumAmount, http.networkCurrency.divisibility),
+					amount: this.formatMosaicAmountWithDivisibility(Number(sumAmount), http.networkCurrency.divisibility),
 					mosaicAliasName: http.networkCurrency.namespaceName
 				};
 			} else {
@@ -569,7 +569,7 @@ class helper {
 
 				return {
 					...mosaicField,
-					amount: this.formatMosaicAmountWithDivisibility(sumAmount, divisibility),
+					amount: this.formatMosaicAmountWithDivisibility(Number(sumAmount), divisibility),
 					mosaicAliasName: MosaicService.extractMosaicNamespace({ mosaicId: mosaics[0].id.toHex() }, mosaicNames)[0]
 				};
 			}

--- a/src/helper.js
+++ b/src/helper.js
@@ -565,20 +565,20 @@ class helper {
 			};
 
 			if (idHex === http.networkCurrency.mosaicId) {
-				mosaicsFieldObject.push({
-					...mosaicField,
+				Object.assign(mosaicField, {
 					amount: this.formatMosaicAmountWithDivisibility(sumAmount, http.networkCurrency.divisibility),
 					mosaicAliasName: http.networkCurrency.namespaceName
 				});
 			} else {
 				const { divisibility } = mosaicInfos.find(info => info.mosaicId === mosaics[0].id.toHex());
 
-				mosaicsFieldObject.push({
-					...mosaicField,
-					amount: helper.formatMosaicAmountWithDivisibility(sumAmount, divisibility),
+				Object.assign(mosaicField, {
+					amount: this.formatMosaicAmountWithDivisibility(sumAmount, divisibility),
 					mosaicAliasName: MosaicService.extractMosaicNamespace({ mosaicId: mosaics[0].id.toHex() }, mosaicNames)
 				});
 			}
+
+			mosaicsFieldObject.push(mosaicField);
 		});
 
 		return mosaicsFieldObject;

--- a/src/infrastructure/MosaicService.js
+++ b/src/infrastructure/MosaicService.js
@@ -256,7 +256,7 @@ class MosaicService {
    	divisibility: mosaicInfo.divisibility,
    	address: mosaicInfo.ownerAddress.plain(),
    	supply: mosaicInfo.supply.compact().toLocaleString('en-US'),
-   	relativeAmount: helper.formatMosaicAmountWithDivisibility(mosaicInfo.supply, mosaicInfo.divisibility),
+   	relativeAmount: helper.formatMosaicAmountWithDivisibility(mosaicInfo.supply.compact(), mosaicInfo.divisibility),
    	revision: mosaicInfo.revision,
    	startHeight: Number(mosaicInfo.startHeight.toString()),
    	duration: Number(mosaicInfo.duration.toString()),
@@ -273,7 +273,7 @@ class MosaicService {
     */
    static formatMosaicAmountView = mosaicAmountView => ({
    	...this.formatMosaicInfo(mosaicAmountView.mosaicInfo),
-   	amount: helper.formatMosaicAmountWithDivisibility(mosaicAmountView.amount, mosaicAmountView.mosaicInfo.divisibility)
+   	amount: helper.formatMosaicAmountWithDivisibility(mosaicAmountView.amount.compact(), mosaicAmountView.mosaicInfo.divisibility)
    })
 
    /**


### PR DESCRIPTION
## What was the issue?
- Mosaic amount wrong display, when sending transaction attached mosaic's Id and namespace. [read here ](https://github.com/symbol/explorer/issues/1051)
- Explorer filtered by mosaic id and showing the amount, instead of sum the amount balance.

## What's the fix?
- removed unused method `networkCurrencyMosaicBuilder`.
- sum the amount of mosaic filtered by mosaic id.
- minor refactor on helper method.