### PR TITLE
[explorer] task: change timezone in local as default

### DIFF
--- a/__tests__/components/fileds/DateField.spec.js
+++ b/__tests__/components/fileds/DateField.spec.js
@@ -21,7 +21,7 @@ const setupStoreMount = () => {
 
 	const propsData = {
 		timestamp: 1615853185,
-		isShowTimestamp: true
+		shouldShowTimestamp: true
 	};
 
 	return shallowMount(DateField, {
@@ -49,19 +49,28 @@ describe('DateField component', () => {
 		unregister();
 	});
 
-	it('processes props data', ()=> {
-		// Assert:
-		expect(wrapper.vm.timestamp).toBe(timestamp);
-		expect(wrapper.vm.isShowTimestamp).toBe(true);
-	});
-
 	it('renders date and timestamp', async () => {
 		// Act:
 		await wrapper.vm.showDate(timestamp);
 
 		// Assert:
 		expect(wrapper.html()).toMatch('<div class=\"date-container\">'
-            + '<span title=\"2021-03-16 08:06:25\">2021-03-16 08:06:25</span> '
-            + '<span class=\"timestamp\">Symbol Time : 1615853185</span></div>');
+			+ '<span title=\"2021-03-16 08:06:25\">2021-03-16 08:06:25</span> '
+			+ '<span class=\"timestamp\">Symbol Time : 1615853185</span></div>');
+	});
+
+	it('renders date only', async () => {
+		// Arrange:
+		wrapper.setProps({
+			timestamp: 1615853185,
+			shouldShowTimestamp: false
+		});
+
+		// Act:
+		await wrapper.vm.showDate(timestamp);
+
+		// Assert:
+		expect(wrapper.html()).toMatch('<div class=\"date-container\">'
+			+ '<span title=\"2021-03-16 08:06:25\">2021-03-16 08:06:25</span>');
 	});
 });

--- a/__tests__/components/fileds/DateField.spec.js
+++ b/__tests__/components/fileds/DateField.spec.js
@@ -49,7 +49,7 @@ describe('DateField component', () => {
 		unregister();
 	});
 
-	it('renders date and timestamp', async () => {
+	it('renders date and timestamp when shouldShowTimestamp is true', async () => {
 		// Act:
 		await wrapper.vm.showDate(timestamp);
 
@@ -59,7 +59,7 @@ describe('DateField component', () => {
 			+ '<span class=\"timestamp\">Symbol Time : 1615853185</span></div>');
 	});
 
-	it('renders date only', async () => {
+	it('renders date only when shouldShowTimestamp is false', async () => {
 		// Arrange:
 		wrapper.setProps({
 			timestamp: 1615853185,

--- a/__tests__/components/fileds/DateField.spec.js
+++ b/__tests__/components/fileds/DateField.spec.js
@@ -1,0 +1,67 @@
+import DateField from '../../../src/components/fields/DateField.vue';
+import UI from '../../../src/store/ui';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { restore } from 'sinon';
+import { register, unregister } from 'timezone-mock';
+import Vuex from 'vuex';
+
+const setupStoreMount = () => {
+	const uiModule = {
+		namespaced: true,
+		getters: {
+			getNameByKey: UI.getters.getNameByKey
+		}
+	};
+
+	const store = new Vuex.Store({
+		modules: {
+			ui:uiModule
+		}
+	});
+
+	const propsData = {
+		timestamp: 1615853185,
+		isShowTimestamp: true
+	};
+
+	return shallowMount(DateField, {
+		store,
+		localVue,
+		propsData
+	});
+};
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('DateField component', () => {
+	// Arrange:
+	const timestamp = 1615853185;
+	let wrapper = {};
+
+	beforeEach(() => {
+		register('Etc/GMT-8');
+		wrapper = setupStoreMount();
+	});
+
+	afterEach(() => {
+		restore();
+		unregister();
+	});
+
+	it('processes props data', ()=> {
+		// Assert:
+		expect(wrapper.vm.timestamp).toBe(timestamp);
+		expect(wrapper.vm.isShowTimestamp).toBe(true);
+	});
+
+	it('renders date and timestamp', async () => {
+		// Act:
+		await wrapper.vm.showDate(timestamp);
+
+		// Assert:
+		expect(wrapper.html()).toMatch('<div class=\"date-container\">'
+            + '<span title=\"2021-03-16 08:06:25\">2021-03-16 08:06:25</span> '
+            + '<span class=\"timestamp\">Symbol Time : 1615853185</span></div>');
+	});
+});

--- a/__tests__/config/jest.setup.js
+++ b/__tests__/config/jest.setup.js
@@ -27,6 +27,7 @@ jest.mock('../../src/infrastructure/http', () => {
 		],
 		accountLabels: {
 			'TBNMIAJEUCUAQYUNEUP2FPULTOQ5SJ2ZTPNWXIA': 'Mock Exchange'
-		}
+		},
+		timezone: 'Local'
 	};
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -15,4 +15,25 @@ describe('Helper', () => {
 			expect(rgb).toEqual({R: 215, G: 158, B: 250});
 		});
 	});
+
+	describe('convertTimestampToDate should', () => {
+		// Arrange:
+		const networkTimestamp = 1615853185;
+
+		it('convert timestamp in utc date', () => {
+			//Act:
+			const date = Helper.convertTimestampToDate(networkTimestamp, 'Local');
+
+			//Assert:
+			expect(date).toEqual("2021-03-16 08:06:25");
+		});
+
+		it('convert timestamp in utc date', () => {
+			//Act:
+			const date = Helper.convertTimestampToDate(networkTimestamp, 'UTC');
+
+			//Assert:
+			expect(date).toEqual("2021-03-16 00:06:25");
+		});
+	});
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -17,31 +17,45 @@ describe('Helper', () => {
 		});
 	});
 
-	describe('convertTimestampToDate should', () => {
+	describe('convertTimestampToDate converts', () => {
 		// Arrange:
 		const networkTimestamp = 1615853185;
+
+		const expectedDateTime = {
+			local: '2021-03-16 08:06:25',
+			UTC: '2021-03-16 00:06:25'
+		};
+
+		beforeEach(() => {
+			register('Etc/GMT-8');
+		});
 
 		afterEach(() => {
 			unregister();
 		});
 
-		it('convert timestamp in local date', () => {
-			// Arrange:
-			register('Etc/GMT-8');
-
+		it('timestamp in local date', () => {
 			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'Local');
 
 			// Assert:
-			expect(date).toEqual('2021-03-16 08:06:25');
+			expect(date).toEqual(expectedDateTime.local);
 		});
 
-		it('convert timestamp in utc date', () => {
+		it('timestamp in utc date', () => {
 			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'UTC');
 
 			// Assert:
-			expect(date).toEqual('2021-03-16 00:06:25');
+			expect(date).toEqual(expectedDateTime.UTC);
+		});
+
+		it('timestamp to default date (local)', () => {
+			// Act:
+			const date = Helper.convertTimestampToDate(networkTimestamp);
+
+			// Assert:
+			expect(date).toEqual(expectedDateTime.local);
 		});
 	});
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -1,4 +1,5 @@
 import Helper from '../src/helper';
+import { register, unregister } from 'timezone-mock';
 
 describe('Helper', () => {
 	describe('hslToRgb should', () => {
@@ -20,20 +21,27 @@ describe('Helper', () => {
 		// Arrange:
 		const networkTimestamp = 1615853185;
 
-		it('convert timestamp in utc date', () => {
-			//Act:
+		afterEach(() => {
+			unregister();
+		});
+
+		it('convert timestamp in local date', () => {
+			// Arrange:
+			register('Etc/GMT-8');
+
+			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'Local');
 
-			//Assert:
-			expect(date).toEqual("2021-03-16 08:06:25");
+			// Assert:
+			expect(date).toEqual('2021-03-16 08:06:25');
 		});
 
 		it('convert timestamp in utc date', () => {
-			//Act:
+			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'UTC');
 
-			//Assert:
-			expect(date).toEqual("2021-03-16 00:06:25");
+			// Assert:
+			expect(date).toEqual('2021-03-16 00:06:25');
 		});
 	});
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -17,7 +17,7 @@ describe('Helper', () => {
 		});
 	});
 
-	describe('convertTimestampToDate converts', () => {
+	describe('convertTimestampToDate', () => {
 		// Arrange:
 		const networkTimestamp = 1615853185;
 
@@ -34,7 +34,7 @@ describe('Helper', () => {
 			unregister();
 		});
 
-		it('timestamp in local date', () => {
+		it('converts timestamp in local date', () => {
 			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'Local');
 
@@ -42,7 +42,7 @@ describe('Helper', () => {
 			expect(date).toEqual(expectedDateTime.local);
 		});
 
-		it('timestamp in utc date', () => {
+		it('converts timestamp in utc date', () => {
 			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp, 'UTC');
 
@@ -50,7 +50,7 @@ describe('Helper', () => {
 			expect(date).toEqual(expectedDateTime.UTC);
 		});
 
-		it('timestamp to default date (local)', () => {
+		it('converts timestamp in default date (local) when timezone type parameter is omitted', () => {
 			// Act:
 			const date = Helper.convertTimestampToDate(networkTimestamp);
 

--- a/__tests__/infrastructure/BlockService.spec.js
+++ b/__tests__/infrastructure/BlockService.spec.js
@@ -133,7 +133,7 @@ describe('Block Service', () => {
 			expect(blockList.data).toHaveLength(10);
 
 			blockList.data.forEach((block, index) => {
-				expect(block.age).toEqual(Helper.convertToUTCDate(epochAdjustment + index + 1));
+				expect(block.age).toEqual(Helper.convertTimestampToDate(epochAdjustment + index + 1));
 				expect(block.blockReward).toEqual(Helper.toNetworkCurrency(block.height * 1000000));
 				expect(block).toHaveProperty('harvester');
 				expect(block.harvester).toHaveProperty('signer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "stylelint": "^11.1.1",
         "stylelint-config-standard": "^19.0.0",
         "stylelint-processor-html": "^1.0.0",
+        "timezone-mock": "^1.3.2",
         "vue-jest": "^3.0.7",
         "vue-template-compiler": "^2.6.11"
       },
@@ -26876,6 +26877,12 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/timezone-mock": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.3.2.tgz",
+      "integrity": "sha512-WxhU4vNGdFT0nnQEC8YDNGbnoVwvLjXjnie/nyFSqT0qNbu+28W1X1NKANjKCAj+9QF+0V5GK0ekG+HXxpOmWQ==",
+      "dev": true
+    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -51102,6 +51109,12 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "timezone-mock": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.3.2.tgz",
+      "integrity": "sha512-WxhU4vNGdFT0nnQEC8YDNGbnoVwvLjXjnie/nyFSqT0qNbu+28W1X1NKANjKCAj+9QF+0V5GK0ekG+HXxpOmWQ==",
+      "dev": true
     },
     "timsort": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "stylelint": "^11.1.1",
     "stylelint-config-standard": "^19.0.0",
     "stylelint-processor-html": "^1.0.0",
+    "timezone-mock": "^1.3.2",
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.11"
   },

--- a/src/components/TimeSince.vue
+++ b/src/components/TimeSince.vue
@@ -17,6 +17,7 @@
 </template>
 <script>
 import moment from 'moment';
+import http from '../infrastructure/http';
 
 export default {
 	name: 'TimeSince',
@@ -53,9 +54,18 @@ export default {
 	},
 	methods: {
 		updateDateAge () {
-			const now = moment(moment.utc(Date.now()).format(), 'YYYY-MM-DD HH:mm:ss').utc();
+			let now, date;
+			switch (http.timezone) {
+				case 'UTC':
+					now = moment(Date.now()).utc();
+					date = moment(this.date).utc();
+					break;
 
-			const date = moment(this.date, 'YYYY-MM-DD HH:mm:ss').utc();
+				case 'Local':
+					now = moment(Date.now()).local();
+					date = moment(this.date).local();
+					break;
+			}
 
 			let diff = Math.max(0, now.diff(date)) || 0;
 

--- a/src/components/fields/DateField.vue
+++ b/src/components/fields/DateField.vue
@@ -18,7 +18,7 @@
 
 <template>
 	<div class="date-container">
-		<span :title="utcDate(timestamp)" >{{ utcDate(timestamp) }}</span>
+		<span :title="showDate(timestamp)" >{{ showDate(timestamp) }}</span>
 
 		<span v-if="isShowTimestamp" class="timestamp">{{ getNameByKey('symbolTime') }} : {{ timestamp }}</span>
 	</div>
@@ -36,8 +36,8 @@ export default {
 		}
 	},
 	methods: {
-		utcDate (timestamp) {
-			return helper.convertToUTCDate(timestamp);
+		showDate (timestamp) {
+			return helper.convertTimestampToDate(timestamp);
 		},
 		getNameByKey (e) {
 			return this.$store.getters['ui/getNameByKey'](e);

--- a/src/components/fields/DateField.vue
+++ b/src/components/fields/DateField.vue
@@ -20,7 +20,7 @@
 	<div class="date-container">
 		<span :title="showDate(timestamp)" >{{ showDate(timestamp) }}</span>
 
-		<span v-if="isShowTimestamp" class="timestamp">{{ getNameByKey('symbolTime') }} : {{ timestamp }}</span>
+		<span v-if="shouldShowTimestamp" class="timestamp">{{ getNameByKey('symbolTime') }} : {{ timestamp }}</span>
 	</div>
 </template>
 <script>
@@ -30,7 +30,7 @@ export default {
 	name: 'DateField',
 	props: {
 		timestamp: Number,
-		isShowTimestamp: {
+		shouldShowTimestamp: {
 			type: Boolean,
 			default: false
 		}

--- a/src/components/tables/TableInfoView.vue
+++ b/src/components/tables/TableInfoView.vue
@@ -17,7 +17,7 @@
 						<BlockHeightWithFinalizedStatusField v-else-if="isBlockHeightWithFinalizedStatus(itemKey)" :value="item" />
 						<Boolean v-else-if="isBoolean(itemKey)" :value="item" style="transform: scale(0.7, 0.7);"/>
 						<Age v-else-if="isAge(itemKey)" :date="item" />
-						<DateField v-else-if="itemKey === 'timestamp'" :timestamp="item" />
+						<DateField v-else-if="isDateField(itemKey)" :timestamp="item" />
 						<MessageField v-else-if="itemKey === 'message'" :value="item" />
 						<Harvester v-else-if="itemKey === 'harvester'" :value="item" />
 

--- a/src/components/tables/TableView.vue
+++ b/src/components/tables/TableView.vue
@@ -161,6 +161,10 @@ export default {
 			return -1 === this.disableClickValues.indexOf(item);
 		},
 
+		isDateField (itemKey) {
+			return 'timestamp' === itemKey || 'deadline' === itemKey;
+		},
+
 		isDecimal (itemKey) {
 			return -1 !== this.changeDecimalColor.indexOf(itemKey);
 		},

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -32,6 +32,7 @@
 				"icon": "IconCurrencyUsd"
 			}
 		]
-	}
+	},
+	"timezone": "Local"
 }
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -263,6 +263,33 @@ class helper {
 	static convertToUTCDate = networkTimestamp => moment.utc(networkTimestamp * 1000).format('YYYY-MM-DD HH:mm:ss')
 
 	/**
+	 * Convert networkTimestamp to date.
+	 * @param {number} networkTimestamp network timestamp in seconds.
+	 * @param {'UTC' | 'Local'} type time zone 'UTC' or 'Local'.
+	 * @returns {string} Date with format YYYY-MM-DD HH:mm:ss.
+	 */
+	static convertTimestampToDate = (networkTimestamp, type = http.timezone) => {
+		// moment using milliseconds as default
+		const date = moment(networkTimestamp * 1000);
+
+		switch (type) {
+		case 'UTC':
+			date.utc();
+			break;
+
+		case 'Local':
+			date.local();
+			break;
+
+		default:
+			date.local();
+			break;
+		}
+
+		return date.format('YYYY-MM-DD HH:mm:ss');
+	}
+
+	/**
 	 * convert difficulty raw score to readable
 	 * @param {UInt64} difficulty - raw difficulty score
 	 * @returns {string} difficulty - readable difficulty score

--- a/src/helper.js
+++ b/src/helper.js
@@ -256,13 +256,6 @@ class helper {
 	}
 
 	/**
-	 * Convert networkTimestamp to UTC date.
-	 * @param {number} networkTimestamp network timestamp.
-	 * @returns {string} UTC date with format YYYY-MM-DD HH:mm:ss.
-	 */
-	static convertToUTCDate = networkTimestamp => moment.utc(networkTimestamp * 1000).format('YYYY-MM-DD HH:mm:ss')
-
-	/**
 	 * Convert networkTimestamp to date.
 	 * @param {number} networkTimestamp network timestamp in seconds.
 	 * @param {'UTC' | 'Local'} type time zone 'UTC' or 'Local'.
@@ -368,13 +361,6 @@ class helper {
 	 */
 	static convertSecondToDate = second => moment.utc().add(second, 's')
 		.format('YYYY.MM.DD @ HH:mm UTC')
-
-	/**
-	 * Convert block deadline to date.
-	 * @param {number} deadline - deadline from block.
-	 * @returns {string} YYYY-MM-DD HH:mm:ss.
-	 */
-	static convertDeadlinetoDate = deadline => this.convertToUTCDate(this.networkTimestamp(deadline))
 
 	/**
 	 * Converts an HSL color value to RGB. Conversion formula

--- a/src/helper.js
+++ b/src/helper.js
@@ -273,10 +273,6 @@ class helper {
 		case 'Local':
 			date.local();
 			break;
-
-		default:
-			date.local();
-			break;
 		}
 
 		return date.format('YYYY-MM-DD HH:mm:ss');

--- a/src/infrastructure/BlockService.js
+++ b/src/infrastructure/BlockService.js
@@ -157,7 +157,7 @@ class BlockService {
 
   			return {
   				...block,
-  				age: helper.convertToUTCDate(block.timestamp),
+  				age: helper.convertTimestampToDate(block.timestamp),
   				blockReward: helper.toNetworkCurrency(blockReward),
   				harvester: {
   					signer: block.signer,

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -205,7 +205,7 @@ class TransactionService {
   		totalRecords,
   		data: transactions.data.map(({ deadline, ...transaction }) => ({
   			...transaction,
-  			age: helper.convertToUTCDate(transaction.transactionInfo.timestamp),
+  			age: helper.convertTimestampToDate(transaction.transactionInfo.timestamp),
   			height: transaction.transactionInfo.height,
   			transactionHash: transaction.transactionInfo.hash,
   			transactionType: transaction.type,

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -222,7 +222,7 @@ class TransactionService {
    */
   static formatTransaction = transaction => ({
   	...transaction,
-  	deadline: helper.convertDeadlinetoDate(transaction.deadline.adjustedValue),
+  	deadline: helper.networkTimestamp(transaction.deadline.adjustedValue),
   	maxFee: helper.toNetworkCurrency(Number(transaction.maxFee.toString())),
   	signer: transaction.signer.address.plain(),
   	transactionBody: this.formatTransactionBody(transaction),
@@ -608,7 +608,7 @@ class TransactionService {
 	  const transactionObj = {
 		  ...transactionDTO,
 		  transactionType: transactionDTO.type,
-		  deadline: helper.convertDeadlinetoDate(transactionDTO.deadline.adjustedValue),
+		  deadline: helper.networkTimestamp(transactionDTO.deadline.adjustedValue),
 		  maxFee: helper.toNetworkCurrency(transactionDTO.maxFee),
 		  signer: transactionDTO.signer.address.plain(),
 		  transactionInfo: this.formatTransactionInfo(transactionDTO.transactionInfo)
@@ -692,7 +692,7 @@ class TransactionService {
 					  signer: cosignature.signer.address.plain()
 				  };
 			  }) : [],
-			  deadline: helper.convertDeadlinetoDate(transactionDTO.deadline.adjustedValue),
+			  deadline: helper.networkTimestamp(transactionDTO.deadline.adjustedValue),
 			  maxFee: helper.toNetworkCurrency(transactionDTO.maxFee),
 			  signer: transactionDTO.signer.address.plain(),
 			  transactionInfo: this.formatTransactionInfo(transactionDTO.transactionInfo),

--- a/src/infrastructure/http.js
+++ b/src/infrastructure/http.js
@@ -93,6 +93,10 @@ export default class http {
   	};
   }
 
+  static get timezone () {
+	  return globalConfig.timezone || 'Local';
+  }
+
   static get marketDataUrl () {
   	return MARKET_DATA_URL;
   }

--- a/src/store/block.js
+++ b/src/store/block.js
@@ -152,7 +152,7 @@ export default {
 
 						getters.timeline.addLatestItem({
 							...latestBlock,
-							age: helper.convertToUTCDate(latestBlock.timestamp),
+							age: helper.convertTimestampToDate(latestBlock.timestamp),
 							blockReward: helper.toNetworkCurrency(blockReward),
 							harvester: {
 								signer: latestBlock.signer,

--- a/src/store/chain.js
+++ b/src/store/chain.js
@@ -158,7 +158,7 @@ export default {
 				epoch: chainInfo.latestFinalizedBlock.finalizationEpoch,
 				lastEpoch: {
 					epoch: lastEpoch,
-					age: helper.convertToUTCDate(timestamp)
+					age: helper.convertTimestampToDate(timestamp)
 				}
 			});
 		}


### PR DESCRIPTION
## What was the issue?
- Current date is in UTC format, we like to change it to local date.

## What's the fix?
- `convertTimestampToDate` method to convert timestamp to date, it accepts `UTC` or `Local`.  default as `Local`
- removed unused `convertDeadlinetoDate` and `convertToUTCDate`