### PR TITLE
[explorer] bug: fix namespace  expiration

### DIFF
--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -300,7 +300,9 @@ class AccountService {
 				return {
 					...namespaces,
 					status: namespaces.active,
-					expirationDuration: helper.convertTimeFromNowInSec(expiredInSecond) || Constants.Message.UNLIMITED
+					expirationDuration: helper.isNativeNamespace(namespaces.name)
+						? Constants.Message.INFINITY
+						: helper.convertTimeFromNowInSec(expiredInSecond)
 				};
 			})
 		};


### PR DESCRIPTION
## What was the issue?
- native namespace display the wrong expiration. It should show `INFINITY` instead of `a few seconds ago`

https://symbol.fyi/accounts/NASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU25TBOA

![image](https://user-images.githubusercontent.com/5649156/186697886-15da0721-6a7d-4e75-86eb-5967eb599778.png)

## What's the fix?
- Added unit test for namespace expiration.
- fixed wrong expiration for native namespace
