### PR TITLE
[explorer] bug: mosaics missing in receipts section

### DIFF
--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -303,7 +303,7 @@ const TestHelper = {
 			type: TransactionType.HASH_LOCK,
 		};
 	},
-	mockFormattedHashLockTransaction: (status) => {
+	createFormattedHashLockTransaction: (status) => {
 		return {
 			amount: UInt64.fromUint(10000000),
 			endHeight: 10,
@@ -315,7 +315,7 @@ const TestHelper = {
 			version: 1
 		}
 	},
-	mockFormattedSecretLockTransaction: (mosaicIdHex, amount, status) => {
+	createFormattedSecretLockTransaction: (mosaicIdHex, amount, status) => {
 		return {
 			amount: UInt64.fromUint(amount),
 			compositeHash: generateRandomHash(64),

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -354,6 +354,14 @@ const TestHelper = {
 			...receiptCommonField,
 			type: 20803,
 		}
+	},
+	mockArtifactExpiryReceipt: (artifactId, type) => {
+		return {
+			artifactId,
+			height: UInt64.fromUint(1000),
+			version: 1,
+			type
+		}
 	}
 };
 

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -295,6 +295,34 @@ const TestHelper = {
 			mosaic: new Mosaic(new MosaicId('6BED913FA20223F8'), UInt64.fromUint(10)),
 			type: TransactionType.HASH_LOCK,
 		};
+	},
+	mockFormattedHashLockTransaction: (status) => {
+		return {
+			amount: UInt64.fromUint(10000000),
+			endHeight: 10,
+			hash: generateRandomHash(64),
+			mosaicId: new MosaicId('6BED913FA20223F8'),
+			ownerAddress: Account.generateNewAccount(NetworkType.TEST_NET).address.plain(),
+			recordId: '631FA269464297FBEBEFE0ED',
+			status,
+			version: 1
+		}
+	},
+	mockFormattedSecretLockTransaction: (mosaicIdHex, amount, status) => {
+		return {
+			amount: UInt64.fromUint(amount),
+			compositeHash: generateRandomHash(64),
+			hashAlgorithm: "Sha3 256",
+			endHeight: 10,
+			mosaicId: new MosaicId(mosaicIdHex),
+			ownerAddress: Account.generateNewAccount(NetworkType.TEST_NET).address.plain(),
+			recipient: Account.generateNewAccount(NetworkType.TEST_NET).address.plain(),
+			recordId: '631FA269464297FBEBEFE0ED',
+			secret: "112233445566",
+			status,
+			version: 1
+		}
+
 	}
 };
 

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -7,7 +7,7 @@ import {
 	Mosaic,
 	UInt64,
 	MosaicId,
-	TransactionType
+	TransactionType,
 } from 'symbol-sdk';
 
 const generateRandomHash = (length = 32) => {
@@ -39,6 +39,13 @@ const transactionCommonField = {
 		feeMultiplier: 10,
 		hash: generateRandomHash()
 	},
+}
+
+const receiptCommonField = {
+	amount: UInt64.fromUint(10000000),
+	height: UInt64.fromUint(1000),
+	mosaicId: new MosaicId('6BED913FA20223F8'),
+	version: 1
 }
 
 const TestHelper = {
@@ -323,6 +330,30 @@ const TestHelper = {
 			version: 1
 		}
 
+	},
+	mockBalanceChangeReceipt: (amount, mosaicIdHex, type) => {
+		return {
+			...receiptCommonField,
+			amount: UInt64.fromUint(amount),
+			mosaicId: new MosaicId(mosaicIdHex),
+			targetAddress: Account.generateNewAccount(NetworkType.TEST_NET).address,
+			type,
+		}
+	},
+	mockBalanceTransferReceipt: (amount, type) => {
+		return {
+			...receiptCommonField,
+			amount: UInt64.fromUint(amount),
+			recipientAddress: Account.generateNewAccount(NetworkType.TEST_NET).address,
+			senderAddress: Account.generateNewAccount(NetworkType.TEST_NET).address,
+			type,
+		}
+	},
+	mockInflationReceipt: () => {
+		return {
+			...receiptCommonField,
+			type: 20803,
+		}
 	}
 };
 

--- a/__tests__/infrastructure/AccountService.spec.js
+++ b/__tests__/infrastructure/AccountService.spec.js
@@ -264,8 +264,8 @@ describe('Account Service', () => {
 			const mockSearchHashLocks = {
 				...pageInfo,
 				data: [
-					TestHelper.mockFormattedHashLockTransaction('Unused'),
-					TestHelper.mockFormattedHashLockTransaction('Used'),
+					TestHelper.createFormattedHashLockTransaction('Unused'),
+					TestHelper.createFormattedHashLockTransaction('Used'),
 				]
 			};
 
@@ -311,8 +311,8 @@ describe('Account Service', () => {
 			const mockSearchSecretLocks = {
 				...pageInfo,
 				data: [
-					TestHelper.mockFormattedSecretLockTransaction(mockTestSecretLockMosaic.idHex, 30, 'Unused'),
-					TestHelper.mockFormattedSecretLockTransaction(mockTestSecretLockMosaic.idHex, 10, 'Used'),
+					TestHelper.createFormattedSecretLockTransaction(mockTestSecretLockMosaic.idHex, 30, 'Unused'),
+					TestHelper.createFormattedSecretLockTransaction(mockTestSecretLockMosaic.idHex, 10, 'Used'),
 				]
 			};
 
@@ -342,16 +342,19 @@ describe('Account Service', () => {
 			expect(secretLockList.pageSize).toEqual(pageInfo.pageSize);
 			expect(secretLockList.data).toHaveLength(2);
 
-			expect(secretLockList.data[0].status).toBe('Unused');
-			expect(secretLockList.data[0].mosaics).toEqual([{
+			const UnusedData = secretLockList.data[0];
+			const UsedData = secretLockList.data[1];
+
+			expect(UnusedData.status).toBe('Unused');
+			expect(UnusedData.mosaics).toEqual([{
 				amount: '30',
 				mosaicAliasName: mockTestSecretLockMosaic.namespaceName,
 				mosaicId: mockTestSecretLockMosaic.idHex,
 				rawAmount: UInt64.fromUint(30)
 			}]);
-			expect(secretLockList.data[1].status).toBe('Used');
 
-			expect(secretLockList.data[1].mosaics).toEqual([{
+			expect(UsedData.status).toBe('Used');
+			expect(UsedData.mosaics).toEqual([{
 				amount: '10',
 				mosaicAliasName: mockTestSecretLockMosaic.namespaceName,
 				mosaicId: mockTestSecretLockMosaic.idHex,
@@ -359,6 +362,7 @@ describe('Account Service', () => {
 			}]);
 
 			secretLockList.data.forEach(secretLock => {
+				// Assert below are constants from createFormattedSecretLockTransaction
 				expect(secretLock.endHeight).toBe(10);
 				expect(secretLock.secret).toBe('112233445566');
 				expect(secretLock.hashAlgorithm).toBe('Sha3 256');

--- a/__tests__/infrastructure/AccountService.spec.js
+++ b/__tests__/infrastructure/AccountService.spec.js
@@ -342,19 +342,19 @@ describe('Account Service', () => {
 			expect(secretLockList.pageSize).toEqual(pageInfo.pageSize);
 			expect(secretLockList.data).toHaveLength(2);
 
-			const UnusedData = secretLockList.data[0];
-			const UsedData = secretLockList.data[1];
+			const unusedData = secretLockList.data[0];
+			const usedData = secretLockList.data[1];
 
-			expect(UnusedData.status).toBe('Unused');
-			expect(UnusedData.mosaics).toEqual([{
+			expect(unusedData.status).toBe('Unused');
+			expect(unusedData.mosaics).toEqual([{
 				amount: '30',
 				mosaicAliasName: mockTestSecretLockMosaic.namespaceName,
 				mosaicId: mockTestSecretLockMosaic.idHex,
 				rawAmount: UInt64.fromUint(30)
 			}]);
 
-			expect(UsedData.status).toBe('Used');
-			expect(UsedData.mosaics).toEqual([{
+			expect(usedData.status).toBe('Used');
+			expect(usedData.mosaics).toEqual([{
 				amount: '10',
 				mosaicAliasName: mockTestSecretLockMosaic.namespaceName,
 				mosaicId: mockTestSecretLockMosaic.idHex,

--- a/__tests__/infrastructure/CreateReceiptTransaction.spec.js
+++ b/__tests__/infrastructure/CreateReceiptTransaction.spec.js
@@ -22,6 +22,7 @@ describe('CreateReceiptTransaction', () => {
             const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
 
             // Assert:
+            expect(receipts.length).toBe(1)
             expect(receipts[0].height).toBe(1000)
             expect(receipts[0].type).toBe(receiptType)
             expect(receipts[0].targetAddress).toBe(mockStatement.targetAddress.plain())
@@ -92,6 +93,7 @@ describe('CreateReceiptTransaction', () => {
                 const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
 
                 // Assert:
+                expect(receipts.length).toBe(1)
                 expect(receipts[0].height).toBe(1000)
                 expect(receipts[0].type).toBe(receiptType)
                 expect(receipts[0].targetAddress).toBe(mockStatement.targetAddress.plain())
@@ -128,6 +130,7 @@ describe('CreateReceiptTransaction', () => {
             const receipts = await CreateReceiptTransaction.balanceTransferReceipt([mockStatement]);
 
             // Assert:
+            expect(receipts.length).toBe(1)
             expect(receipts[0].height).toBe(1000)
             expect(receipts[0].type).toBe(receiptType)
             expect(receipts[0].senderAddress).toBe(mockStatement.senderAddress.plain())
@@ -160,6 +163,7 @@ describe('CreateReceiptTransaction', () => {
             const receipts = await CreateReceiptTransaction.inflationReceipt([mockStatement]);
 
             // Assert:
+            expect(receipts.length).toBe(1)
             expect(receipts[0].height).toBe(1000)
             expect(receipts[0].type).toBe(ReceiptType.Inflation)
             expect(receipts[0].version).toBe(1)
@@ -182,6 +186,7 @@ describe('CreateReceiptTransaction', () => {
             const receipts = await CreateReceiptTransaction.artifactExpiryReceipt([mockStatement]);
 
             // Assert:
+            expect(receipts.length).toBe(1)
             expect(receipts[0].height).toBe(1000)
             expect(receipts[0].type).toBe(receiptType)
             expect(receipts[0].version).toBe(1)

--- a/__tests__/infrastructure/CreateReceiptTransaction.spec.js
+++ b/__tests__/infrastructure/CreateReceiptTransaction.spec.js
@@ -1,0 +1,175 @@
+import Helper from '../../src/helper';
+import { CreateReceiptTransaction } from '../../src/infrastructure';
+import { stub, restore } from 'sinon';
+import {
+	NamespaceId,
+	UInt64,
+	NamespaceName,
+    ReceiptType
+} from 'symbol-sdk';
+import TestHelper from '../TestHelper';
+import http from '../../src/infrastructure/http';
+
+describe('CreateReceiptTransaction', () => {
+
+    describe('balanceChangeReceipt', () => {
+        const runBasicBalanceChangeReceiptTests = async (receiptType, expectedResult) => {
+            // Arrange:
+            const mockStatement = TestHelper.mockBalanceChangeReceipt(10000000, http.networkCurrency.mosaicId, receiptType);
+
+            // Act:
+            const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
+
+            // Assert:
+            expect(receipts[0].height).toBe(1000)
+            expect(receipts[0].type).toBe(receiptType)
+            expect(receipts[0].targetAddress).toBe(mockStatement.targetAddress.plain())
+            expect(receipts[0].version).toBe(1)
+            expect(receipts[0].mosaics).toEqual([{
+                amount: '10.000000',
+                mosaicAliasName: http.networkCurrency.namespaceName,
+                mosaicId: http.networkCurrency.mosaicId,
+                rawAmount: UInt64.fromUint(10000000)
+            }])
+            expect(receipts[0].receiptType).toBe(expectedResult)
+        }
+
+        describe('harvestFee', () => {
+            afterEach(restore);
+
+            it('returns harvest fee receipt', async () => {
+                await runBasicBalanceChangeReceiptTests(ReceiptType.Harvest_Fee, 'Harvest Fee')
+            })
+        })
+
+        describe('LockHash', () => {
+            afterEach(restore);
+
+            it('returns lock hash created receipt', async () => {
+                await runBasicBalanceChangeReceiptTests(ReceiptType.LockHash_Created, 'LockHash Created');
+            })
+
+            it('resolves mosaics in lock hash completed receipt', async () => {
+                await runBasicBalanceChangeReceiptTests(ReceiptType.LockHash_Completed, 'LockHash Completed');
+            })
+
+            it('resolves mosaics in lock hash expired receipt', async () => {
+                await runBasicBalanceChangeReceiptTests(ReceiptType.LockHash_Expired, 'LockHash Expired');
+            })
+        })
+
+        describe('LockSecret', () => {
+            afterEach(restore);
+
+            const runBasicLockSecretReceiptTests = async (receiptType, expectedResult) => {
+                // Arrange:
+                const mockTestSecretLockMosaic = {
+                    idHex: '22D2D90A27738AA0',
+                    namespaceName: 'secret_lock_mosaic'
+                };
+
+                const mockStatement = TestHelper.mockBalanceChangeReceipt(10, mockTestSecretLockMosaic.idHex, receiptType);
+
+                const mockMosaicInfoAndNamespace = {
+                    mosaicInfos: [
+                        TestHelper.mockMosaicInfo(mockTestSecretLockMosaic.idHex, 'TC46AZWUIZYZ2WVGLVEZYNZHSIFAD3AFDPUJMEA', 2, 0)
+                    ],
+                    mosaicNames: [
+                        {
+                            names: [new NamespaceName(new NamespaceId(mockTestSecretLockMosaic.namespaceName), mockTestSecretLockMosaic.namespaceName)],
+                            mosaicId: mockTestSecretLockMosaic.idHex
+                        }
+                    ],
+                    unresolvedMosaicsMap: {
+                        "22D2D90A27738AA0": '22D2D90A27738AA0'
+                    }
+                }
+
+                stub(Helper, 'getMosaicInfoAndNamespace').returns(Promise.resolve(mockMosaicInfoAndNamespace));
+
+                // Act:
+                const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
+
+                // Assert:
+                expect(receipts[0].height).toBe(1000)
+                expect(receipts[0].type).toBe(receiptType)
+                expect(receipts[0].targetAddress).toBe(mockStatement.targetAddress.plain())
+                expect(receipts[0].version).toBe(1)
+                expect(receipts[0].mosaics).toEqual([{
+                    amount: '10',
+                    mosaicAliasName: mockTestSecretLockMosaic.namespaceName,
+                    mosaicId: mockTestSecretLockMosaic.idHex,
+                    rawAmount: UInt64.fromUint(10)
+                }])
+                expect(receipts[0].receiptType).toBe(expectedResult)
+            }
+
+            it('resolves mosaics in lock secret created receipt', async () => {
+                await runBasicLockSecretReceiptTests(ReceiptType.LockSecret_Created, 'LockSecret Created')
+            })
+
+            it('resolves mosaics in lock secret completed receipt', async () => {
+                await runBasicLockSecretReceiptTests(ReceiptType.LockSecret_Completed, 'LockSecret Completed')
+            })
+
+            it('resolves mosaics in lock secret expired receipt', async () => {
+                await runBasicLockSecretReceiptTests(ReceiptType.LockSecret_Expired, 'LockSecret Expired')
+            })
+        })
+    })
+
+    describe('balanceTransferReceipt', () => {
+        const runBasicBalanceTransferReceiptTests = async (receiptType, expectedResult) => {
+            // Arrange:
+            const mockStatement = TestHelper.mockBalanceTransferReceipt(10000000, receiptType);
+
+            // Act:
+            const receipts = await CreateReceiptTransaction.balanceTransferReceipt([mockStatement]);
+
+            // Assert:
+            expect(receipts[0].height).toBe(1000)
+            expect(receipts[0].type).toBe(receiptType)
+            expect(receipts[0].senderAddress).toBe(mockStatement.senderAddress.plain())
+            expect(receipts[0].recipient).toBe(mockStatement.recipientAddress.plain())
+            expect(receipts[0].version).toBe(1)
+            expect(receipts[0].mosaics).toEqual([{
+                amount: '10.000000',
+                mosaicAliasName: http.networkCurrency.namespaceName,
+                mosaicId: http.networkCurrency.mosaicId,
+                rawAmount: UInt64.fromUint(10000000)
+            }])
+            expect(receipts[0].receiptType).toBe(expectedResult)
+        }
+
+        it('returns mosaic rental fee receipt', async () => {
+            await runBasicBalanceTransferReceiptTests(ReceiptType.Mosaic_Rental_Fee, 'Mosaic Rental Fee')
+        })
+
+        it('returns namespace rental fee receipt', async () => {
+            await runBasicBalanceTransferReceiptTests(ReceiptType.Namespace_Rental_Fee, 'Namespace Rental Fee')
+        })
+    })
+
+    describe('inflationReceipt', () => {
+        it('returns inflation receipt', async () => {
+            // Arrange:
+            const mockStatement = TestHelper.mockInflationReceipt();
+
+            // Act:
+            const receipts = await CreateReceiptTransaction.inflationReceipt([mockStatement]);
+
+            // Assert:
+            expect(receipts[0].height).toBe(1000)
+            expect(receipts[0].type).toBe(ReceiptType.Inflation)
+            expect(receipts[0].version).toBe(1)
+            expect(receipts[0].mosaics).toEqual([{
+                amount: '10.000000',
+                mosaicAliasName: http.networkCurrency.namespaceName,
+                mosaicId: http.networkCurrency.mosaicId,
+                rawAmount: UInt64.fromUint(10000000)
+            }])
+            expect(receipts[0].receiptType).toBe('Inflation')
+        })
+
+    })
+})

--- a/__tests__/infrastructure/CreateReceiptTransaction.spec.js
+++ b/__tests__/infrastructure/CreateReceiptTransaction.spec.js
@@ -1,5 +1,5 @@
 import Helper from '../../src/helper';
-import { CreateReceiptTransaction } from '../../src/infrastructure';
+import { ReceiptExtractor } from '../../src/infrastructure';
 import { stub, restore } from 'sinon';
 import {
 	NamespaceId,
@@ -11,7 +11,7 @@ import {
 import TestHelper from '../TestHelper';
 import http from '../../src/infrastructure/http';
 
-describe('CreateReceiptTransaction', () => {
+describe('ReceiptExtractor', () => {
 
     describe('balanceChangeReceipt', () => {
         const runBasicBalanceChangeReceiptTests = async (receiptType, expectedResult) => {
@@ -19,7 +19,7 @@ describe('CreateReceiptTransaction', () => {
             const mockStatement = TestHelper.mockBalanceChangeReceipt(10000000, http.networkCurrency.mosaicId, receiptType);
 
             // Act:
-            const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
+            const receipts = await ReceiptExtractor.balanceChangeReceipt([mockStatement]);
 
             // Assert:
             expect(receipts.length).toBe(1)
@@ -90,7 +90,7 @@ describe('CreateReceiptTransaction', () => {
                 stub(Helper, 'getMosaicInfoAndNamespace').returns(Promise.resolve(mockMosaicInfoAndNamespace));
 
                 // Act:
-                const receipts = await CreateReceiptTransaction.balanceChangeReceipt([mockStatement]);
+                const receipts = await ReceiptExtractor.balanceChangeReceipt([mockStatement]);
 
                 // Assert:
                 expect(receipts.length).toBe(1)
@@ -127,7 +127,7 @@ describe('CreateReceiptTransaction', () => {
             const mockStatement = TestHelper.mockBalanceTransferReceipt(10000000, receiptType);
 
             // Act:
-            const receipts = await CreateReceiptTransaction.balanceTransferReceipt([mockStatement]);
+            const receipts = await ReceiptExtractor.balanceTransferReceipt([mockStatement]);
 
             // Assert:
             expect(receipts.length).toBe(1)
@@ -160,7 +160,7 @@ describe('CreateReceiptTransaction', () => {
             const mockStatement = TestHelper.mockInflationReceipt();
 
             // Act:
-            const receipts = await CreateReceiptTransaction.inflationReceipt([mockStatement]);
+            const receipts = await ReceiptExtractor.inflationReceipt([mockStatement]);
 
             // Assert:
             expect(receipts.length).toBe(1)
@@ -183,7 +183,7 @@ describe('CreateReceiptTransaction', () => {
             const mockStatement = TestHelper.mockArtifactExpiryReceipt(artifactId, receiptType);
 
             // Act:
-            const receipts = await CreateReceiptTransaction.artifactExpiryReceipt([mockStatement]);
+            const receipts = await ReceiptExtractor.artifactExpiryReceipt([mockStatement]);
 
             // Assert:
             expect(receipts.length).toBe(1)

--- a/src/helper.js
+++ b/src/helper.js
@@ -706,6 +706,10 @@ class helper {
 			}
 		});
 
+		return await helper.getMosaicInfoAndNamespace(unresolvedMosaics);
+	}
+
+	static getMosaicInfoAndNamespace = async unresolvedMosaics => {
 		const unresolvedMosaicsMap = {};
 
 		// create resolved mosaic mapping

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -424,17 +424,15 @@ class AccountService {
 		};
 		const accountHashLocks = await LockService.searchHashLocks(searchCriteria);
 
-		const mosaics = accountHashLocks.data.map(hashlock => new Mosaic(hashlock.mosaicId, hashlock.amount));
-
-		const mosaicsFieldObject = await helper.mosaicsFieldObjectBuilder(mosaics);
-
 		let hashLocks = [];
 
 		for (const hashLock of accountHashLocks.data) {
+			const mosaics = [new Mosaic(hashLock.mosaicId, hashLock.amount)];
+
 			hashLocks.push({
 				...hashLock,
 				transactionHash: hashLock.hash,
-				mosaics: [mosaicsFieldObject.find(mosaicFieldObject => mosaicFieldObject.mosaicId === hashLock.mosaicId.toHex())]
+				mosaics: helper.mosaicsFieldObjectBuilder(mosaics)
 			});
 		}
 
@@ -464,14 +462,19 @@ class AccountService {
 
 		const mosaics = accountSecretLocks.data.map(secretlock => new Mosaic(secretlock.mosaicId, secretlock.amount));
 
-		const mosaicsFieldObject = await helper.mosaicsFieldObjectBuilder(mosaics);
+		const { mosaicInfos, mosaicNames, unresolvedMosaicsMap } = await helper.getMosaicInfoAndNamespace(mosaics);
 
 		let secretLocks = [];
 
 		for (const secretLock of accountSecretLocks.data) {
 			secretLocks.push({
 				...secretLock,
-				mosaics: [mosaicsFieldObject.find(mosaicFieldObject => mosaicFieldObject.mosaicId === secretLock.mosaicId.toHex())]
+				mosaics: helper.mosaicsFieldObjectBuilder([
+    				new Mosaic(
+    					new MosaicId(unresolvedMosaicsMap[secretLock.mosaicId.toHex()]),
+    					secretLock.amount
+    				)
+    			], mosaicInfos, mosaicNames),
 			});
 		}
 

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -27,8 +27,7 @@ import {
 	MetadataService,
 	LockService,
 	ReceiptService,
-	MosaicService,
-	BlockService
+	MosaicService
 } from '../infrastructure';
 import nem from 'nem-sdk';
 import {
@@ -470,11 +469,11 @@ class AccountService {
 			secretLocks.push({
 				...secretLock,
 				mosaics: helper.mosaicsFieldObjectBuilder([
-    				new Mosaic(
-    					new MosaicId(unresolvedMosaicsMap[secretLock.mosaicId.toHex()]),
-    					secretLock.amount
-    				)
-    			], mosaicInfos, mosaicNames),
+					new Mosaic(
+						new MosaicId(unresolvedMosaicsMap[secretLock.mosaicId.toHex()]),
+						secretLock.amount
+					)
+    			], mosaicInfos, mosaicNames)
 			});
 		}
 

--- a/src/infrastructure/ReceiptExtractor.js
+++ b/src/infrastructure/ReceiptExtractor.js
@@ -2,7 +2,7 @@ import Constants from '../config/constants';
 import helper from '../helper';
 import { Mosaic, ReceiptType, MosaicId } from 'symbol-sdk';
 
-class CreateReceiptTransaction {
+class ReceiptExtractor {
     static balanceChangeReceipt = async transactionStatement => {
     	let balanceChangeReceipt = [];
 
@@ -87,4 +87,4 @@ class CreateReceiptTransaction {
     }
 }
 
-export default CreateReceiptTransaction;
+export default ReceiptExtractor;

--- a/src/infrastructure/ReceiptService.js
+++ b/src/infrastructure/ReceiptService.js
@@ -19,7 +19,7 @@
 import http from './http';
 import Constants from '../config/constants';
 import {
-	CreateReceiptTransaction
+	ReceiptExtractor
 } from '../infrastructure';
 import { take, toArray } from 'rxjs/operators';
 import { ReceiptType, ResolutionType } from 'symbol-sdk';
@@ -119,13 +119,13 @@ class ReceiptService {
 		const { receiptTransactionStatementType } = transactionStatement;
 		switch (receiptTransactionStatementType) {
 		case Constants.ReceiptTransactionStatementType.BalanceChangeReceipt:
-			return CreateReceiptTransaction.balanceChangeReceipt(transactionStatement.data);
+			return ReceiptExtractor.balanceChangeReceipt(transactionStatement.data);
 		case Constants.ReceiptTransactionStatementType.BalanceTransferReceipt:
-			return CreateReceiptTransaction.balanceTransferReceipt(transactionStatement.data);
+			return ReceiptExtractor.balanceTransferReceipt(transactionStatement.data);
 		case Constants.ReceiptTransactionStatementType.ArtifactExpiryReceipt:
-			return CreateReceiptTransaction.artifactExpiryReceipt(transactionStatement.data);
+			return ReceiptExtractor.artifactExpiryReceipt(transactionStatement.data);
 		case Constants.ReceiptTransactionStatementType.InflationReceipt:
-			return CreateReceiptTransaction.inflationReceipt(transactionStatement.data);
+			return ReceiptExtractor.inflationReceipt(transactionStatement.data);
 		default:
 			throw new Error('Unimplemented receipt transaction statement with type ' + receiptTransactionStatementType);
 		}

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -143,7 +143,7 @@ class TransactionService {
 
   	const mosaics = [new Mosaic(hashInfo.mosaicId, hashInfo.amount)];
 
-  	const mosaicsFieldObject = await helper.mosaicsFieldObjectBuilder(mosaics);
+  	const mosaicsFieldObject = helper.mosaicsFieldObjectBuilder(mosaics);
 
   	return {
 		  ...hashInfo,

--- a/src/infrastructure/index.js
+++ b/src/infrastructure/index.js
@@ -1,7 +1,6 @@
 import AccountService from './AccountService';
 import BlockService from './BlockService';
 import ChainService from './ChainService';
-import CreateReceiptTransaction from './CreateReceiptTransaction';
 import CreateTransaction from './CreateTransaction';
 import DataService from './DataService';
 import FinalizationService from './FinalizationService';
@@ -13,6 +12,7 @@ import MultisigService from './MultisigService';
 import NamespaceService from './NamespaceService';
 import NetworkService from './NetworkService';
 import NodeService from './NodeService';
+import ReceiptExtractor from './ReceiptExtractor';
 import ReceiptService from './ReceiptService';
 import RestrictionService from './RestrictionService';
 import StatisticService from './StatisticService';
@@ -36,6 +36,6 @@ export {
 	StatisticService,
 	LockService,
 	CreateTransaction,
-	CreateReceiptTransaction,
+	ReceiptExtractor,
 	FinalizationService
 };


### PR DESCRIPTION
## What was the issue?
- Mosaics information missing on receipt 
 
## What's the fix?
- refactor in Receipt, Hash Lock and Secret Lock transaction.  Apply with the latest `mosaicsFieldObjectBuilder` change
- refactor `getTransactionMosaicInfoAndNamespace` move out query MosaicInfoAndNamespace logic to new method `getMosaicInfoAndNamespace`
- added unit test for those change

