### PR TITLE
[explorer] fix: display metadata values correctly

### DIFF
--- a/__tests__/infrastructure/MetadataService.spec.js
+++ b/__tests__/infrastructure/MetadataService.spec.js
@@ -1,0 +1,113 @@
+import { MetadataService } from '../../src/infrastructure';
+
+// Arrange:
+jest.mock('../../src/infrastructure/http', () => {
+	const {
+		MosaicId,
+		Address,
+		MetadataType,
+		UInt64
+	} = require('symbol-sdk');
+
+	const commonMetadataEntryProperties = {
+		version: 1,
+		compositeHash: '24E125C7CC30B258778B370A05F4D41104C59C899FD9C67DD0B043F7A39CD7C7',
+		sourceAddress: Address.createFromRawAddress('TCG72DW2OS6GQJRTUKTYCEPVYOAB33HIM2TDRPI'),
+		scopedMetadataKey: UInt64.fromHex('0000676E69746172'),
+		targetAddress: Address.createFromRawAddress('TAEYC7NUBWLJDTWDQSD7PGPZ3J7BB6S6ZRWH6VY')
+	};
+
+	return {
+		createRepositoryFactory: {
+			createMetadataRepository: () => {
+				return {
+					search: () => {
+						return {
+							toPromise: () => {
+								return {
+									data: [
+										{
+											id: '633AF9E4464297FBEB0D3C78',
+											metadataEntry: {
+												...commonMetadataEntryProperties,
+												metadataType: MetadataType.Mosaic,
+												value: 'mosaic metadata',
+												targetId: new MosaicId('3DCE9365EAF9ED2F')
+											}
+										},
+										{
+											id: '633AF986464297FBEB0D3C0C',
+											metadataEntry: {
+												...commonMetadataEntryProperties,
+												metadataType: MetadataType.Namespace,
+												value: 'namespace metadata',
+												targetId: new MosaicId('88F51D7777385EA4')
+											}
+										},
+										{
+											id: '633AF6E0464297FBEB0D38AE',
+											metadataEntry: {
+												...commonMetadataEntryProperties,
+												metadataType: MetadataType.Account,
+												value: 'account metadata'
+											}
+										}
+									],
+									isLastPage: true,
+									pageNumber: 1,
+									pageSize: 10
+								};
+							}
+						};
+					}
+				};
+			}
+		}
+	};
+});
+
+describe('MetadataService', () => {
+	describe('searchMetadatas', () => {
+		it('returns pagination metadatas dto', async () => {
+			// Arrange + Act:
+			const { isLastPage, pageNumber, pageSize, data } = await MetadataService.searchMetadatas({});
+
+			// Assert:
+			const commonMetadataEntryDto= {
+				version: 1,
+				compositeHash: '24E125C7CC30B258778B370A05F4D41104C59C899FD9C67DD0B043F7A39CD7C7',
+				scopedMetadataKey: '0000676E69746172',
+				sourceAddress: 'TCG72DW2OS6GQJRTUKTYCEPVYOAB33HIM2TDRPI',
+				targetAddress: 'TAEYC7NUBWLJDTWDQSD7PGPZ3J7BB6S6ZRWH6VY'
+			};
+
+			expect(isLastPage).toBe(true);
+			expect(pageNumber).toBe(1);
+			expect(pageSize).toBe(10);
+			expect(data.length).toBe(3);
+			expect(data).toEqual([
+				{
+					...commonMetadataEntryDto,
+					metadataId: '633AF9E4464297FBEB0D3C78',
+					metadataType: 'Mosaic',
+					targetId: '3DCE9365EAF9ED2F',
+					value: 'mosaic metadata'
+				},
+				{
+					...commonMetadataEntryDto,
+					metadataId: '633AF986464297FBEB0D3C0C',
+					metadataType: 'Namespace',
+					targetId: '88F51D7777385EA4',
+					value: 'namespace metadata'
+				},
+				{
+					...commonMetadataEntryDto,
+					metadataId: '633AF6E0464297FBEB0D38AE',
+					metadataType: 'Account',
+					targetId: 'N/A',
+					value: 'account metadata'
+				}
+			]);
+		});
+	});
+});

--- a/src/config/filters.js
+++ b/src/config/filters.js
@@ -239,14 +239,14 @@ export const metadata = [
 		value: {}
 	},
 	{
-		label: 'Address Alias',
+		label: 'Account',
 		icon: 'mdi-account',
 		value: {
 			metadataType: MetadataType.Account
 		}
 	},
 	{
-		label: 'Mosaic Alias',
+		label: 'Mosaic',
 		icon: 'mdi-circle',
 		value: {
 			metadataType: MetadataType.Mosaic

--- a/src/config/pages/account-detail.json
+++ b/src/config/pages/account-detail.json
@@ -180,14 +180,15 @@
 				"type": "CardTable",
 				"title": "metadataEntriesTitle",
 				"managerGetter": "account/metadatas",
-				"pagination": "client",
-				"pageSize": 5,
+				"pagination": "server",
 				"hideOnError": true,
 				"hasFilter":true,
 				"hideDependOnGetter": "account/info",
 				"fields": [
 					"scopedMetadataKey",
-					"senderAddress",
+					"targetId",
+					"metadataType",
+					"sourceAddress",
 					"targetAddress",
 					"value"
 				]

--- a/src/config/pages/mosaic-detail.json
+++ b/src/config/pages/mosaic-detail.json
@@ -55,13 +55,13 @@
                 "managerGetter": "mosaic/metadatas",
                 "errorMessage": "metadataEntriesError",
                 "pagination": "server",
-                "hasFilter": true,
+                "hideOnError": true,
+                "hasFilter": false,
                 "fields": [
                     "scopedMetadataKey",
-                    "targetId",
-                    "senderAddress",
+                    "sourceAddress",
                     "targetAddress",
-                    "metadataValue"
+                    "value"
                 ]
             },
             {

--- a/src/config/pages/namespace-detail.json
+++ b/src/config/pages/namespace-detail.json
@@ -52,13 +52,13 @@
                 "managerGetter": "namespace/metadatas",
                 "errorMessage": "metadataEntriesError",
                 "pagination": "server",
-                "hasFilter": true,
+                "hideOnError": true,
+                "hasFilter": false,
                 "fields": [
                     "scopedMetadataKey",
-                    "targetId",
-                    "senderAddress",
+                    "sourceAddress",
                     "targetAddress",
-                    "metadataValue"
+                    "value"
                 ]
             },
             {


### PR DESCRIPTION
## What was the issue?
- metadata information is not displayed correctly.

## What's the fix?
- adjust config for metadata section on account, mosaic, and namespace pages.
- rename filter name.
- turn off the filter option on the mosaic and namespace page.
- added unit test for metadata service.

/accounts/TAEYC7NUBWLJDTWDQSD7PGPZ3J7BB6S6ZRWH6VY
<img width="1335" alt="Screenshot 2022-10-05 at 6 12 34 AM" src="https://user-images.githubusercontent.com/5649156/193940669-682e21bb-2037-4340-873e-65010e31ea53.png">

/mosaics/3DCE9365EAF9ED2F
<img width="1320" alt="Screenshot 2022-10-05 at 6 14 38 AM" src="https://user-images.githubusercontent.com/5649156/193940658-ffbf5016-4ea3-4a62-aafa-bf9eec4cdcc0.png">

/namespaces/88F51D7777385EA4
<img width="1336" alt="Screenshot 2022-10-05 at 6 14 16 AM" src="https://user-images.githubusercontent.com/5649156/193940666-93af26da-42ca-469d-805a-29d02088e3b4.png">