### PR TITLE
[explorer] task: update symbol-sdk to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "merkletreejs": "^0.2.31",
         "moment-timezone": "^0.5.35",
         "nem-sdk": "^1.6.8",
-        "symbol-sdk": "^2.0.1",
+        "symbol-sdk": "^2.0.2",
         "symbol-statistics-service-typescript-fetch-client": "^1.1.5",
         "url-parse": "^1.5.10",
         "vue": "^2.6.14",
@@ -26986,9 +26986,9 @@
       "integrity": "sha512-Md3/wkYLWTeJ/o99kXajW5dDs7Ok7AWfGRGDThb2bpC53KVxwnMl2ho/KUPT2Y+CeuIB62+Hgp9NtJLvgXYzHw=="
     },
     "node_modules/symbol-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.1.tgz",
-      "integrity": "sha512-0yMImFQIMWS5uMKh4jD1ZjdIV1JqFCweggYdnDhZHYjJIgnfBXFjE9yXEwkbScIKTuuOmtma/x7y36aCaq7h5w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.2.tgz",
+      "integrity": "sha512-MlQgOTCiD30TaEq7/43Wt2pgU1vIRceLLhy6JQsxFYj307uPZrBDfpXpU54K1rgYQf4Ze/GgFU3pfgroNYIjjw==",
       "dependencies": {
         "@js-joda/core": "^3.2.0",
         "catbuffer-typescript": "^1.0.1",
@@ -51566,9 +51566,9 @@
       "integrity": "sha512-Md3/wkYLWTeJ/o99kXajW5dDs7Ok7AWfGRGDThb2bpC53KVxwnMl2ho/KUPT2Y+CeuIB62+Hgp9NtJLvgXYzHw=="
     },
     "symbol-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.1.tgz",
-      "integrity": "sha512-0yMImFQIMWS5uMKh4jD1ZjdIV1JqFCweggYdnDhZHYjJIgnfBXFjE9yXEwkbScIKTuuOmtma/x7y36aCaq7h5w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-2.0.2.tgz",
+      "integrity": "sha512-MlQgOTCiD30TaEq7/43Wt2pgU1vIRceLLhy6JQsxFYj307uPZrBDfpXpU54K1rgYQf4Ze/GgFU3pfgroNYIjjw==",
       "requires": {
         "@js-joda/core": "^3.2.0",
         "catbuffer-typescript": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "merkletreejs": "^0.2.31",
     "moment-timezone": "^0.5.35",
     "nem-sdk": "^1.6.8",
-    "symbol-sdk": "^2.0.1",
+    "symbol-sdk": "^2.0.2",
     "symbol-statistics-service-typescript-fetch-client": "^1.1.5",
     "url-parse": "^1.5.10",
     "vue": "^2.6.14",


### PR DESCRIPTION
## What was the issue?
- Old SDK has a problem handling meta info when the value is undefined.

## What's the fix?
- updated latest SDK 2.0.2

This latest SDK fix issue #1106 #1105