### PR TITLE
[explorer] fix: horizontal scrollbar issue

### DIFF
--- a/src/components/tables/TableListView.vue
+++ b/src/components/tables/TableListView.vue
@@ -75,26 +75,28 @@
 					</tr>
 				</tbody>
 			</table>
-			<div v-if="pagination || timelinePagination" class="bottom">
-				<div class="pagination-wrapper">
-					<Pagination
-						:canFetchPrevious="prevPageExist"
-						:canFetchNext="nextPageExist"
-						:goUp="false"
-						:currentPageNumber="pageNumber"
-						:lastPageNumber="lastPage"
-						class="pagination"
-						@next="nextPage"
-						@previous="prevPage"
-						@firstPage="goFirstPage"
-						@lastPage="goLastPage"
-						@fetchPage="fetchPage($event)"
-					/>
-					<Loading small v-if="paginationLoading" />
-				</div>
+		</div>
+
+		<div v-else class="empty-data">{{emptyDataMessageFormatted}}</div>
+
+		<div v-if="(pagination || timelinePagination) && dataIsNotEmpty" class="bottom">
+			<div class="pagination-wrapper">
+				<Pagination
+					:canFetchPrevious="prevPageExist"
+					:canFetchNext="nextPageExist"
+					:goUp="false"
+					:currentPageNumber="pageNumber"
+					:lastPageNumber="lastPage"
+					class="pagination"
+					@next="nextPage"
+					@previous="prevPage"
+					@firstPage="goFirstPage"
+					@lastPage="goLastPage"
+					@fetchPage="fetchPage($event)"
+				/>
+				<Loading small v-if="paginationLoading" />
 			</div>
 		</div>
-		<div v-else class="empty-data">{{emptyDataMessageFormatted}}</div>
 	</div>
 </template>
 
@@ -327,7 +329,10 @@ export default {
 
 <style lang="scss" scoped>
 .table-view {
-    overflow: auto;
+    .table-wrapper {
+        display: block;
+        overflow: auto;
+    }
 
     .pointer {
         cursor: pointer;

--- a/src/views/PageAssembler.vue
+++ b/src/views/PageAssembler.vue
@@ -212,7 +212,7 @@ export default {
         }
     }
 
-    @media screen and (min-width: 80em) {
+    @media screen and (min-width: 1300px) {
         .page-content-card-f {
             padding-left: 80px;
             padding-right: 80px;


### PR DESCRIPTION
## What was the issue?
- Because media screen queries cause the horizontal scrollbar appears when the screen size is big enough. 

## What's the fix?
- We like to keep all columns in the table, so technically the horizontal scrollbar will be helpful on the small screen.
-  I adjusted the `min-width` screen size to 1300px.