### PR TITLE
[explorer] fix: partial transaction display fee issue

### DIFF
--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -7,7 +7,8 @@ import {
 	Mosaic,
 	UInt64,
 	MosaicId,
-	TransactionType
+	TransactionType,
+	TransactionInfo
 } from 'symbol-sdk';
 
 const generateRandomHash = (length = 32) => {
@@ -241,14 +242,7 @@ const TestHelper = {
 		return {
 			...transactionCommonField,
 			type: TransactionType.TRANSFER,
-			transactionInfo: {
-				index: 1,
-				id: 1,
-				height,
-				timestamp,
-				feeMultiplier: 10,
-				hash: generateRandomHash()
-			},
+			transactionInfo: new TransactionInfo(height, 1, 1, timestamp, 10, generateRandomHash()),
 			recipientAddress: {
 				address: Account.generateNewAccount(NetworkType.TEST_NET).address
 			},

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -362,6 +362,14 @@ const TestHelper = {
 			version: 1,
 			type
 		};
+	},
+	createPartialAggregateTransaction: (cosignatures = [], innerTransactions = []) => {
+		return {
+			...transactionCommonField,
+			type: TransactionType.AGGREGATE_BONDED,
+			cosignatures,
+			innerTransactions
+		};
 	}
 };
 

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -162,6 +162,52 @@ describe('Transaction Service', () => {
 			expect(status).toEqual(transactionStatus.detail.code);
 			expect(confirm).toEqual(transactionStatus.message);
 		});
+
+		it('returns unconfirmed transfer transaction with max fee', async () => {
+			// Arrange:
+			const transactionStatus = {
+				message: 'unconfirmed',
+				detail: {
+					code: 'Success'
+				}
+			};
+
+			const transferTransaction = TestHelper.mockTransaction({
+				height: 0,
+				timestamp: 0
+			});
+
+			const transactionFromSDK = {
+				...transferTransaction,
+				...transferTransactionFromSDK,
+			};
+
+			stub(TransactionService, 'getTransactionStatus').returns(Promise.resolve(transactionStatus));
+
+			stub(TransactionService, 'getTransaction').returns(Promise.resolve(transferTransaction));
+
+			stub(TransactionService, 'createTransactionFromSDK').returns(Promise.resolve(transactionFromSDK));
+
+			// Act:
+			const {
+				blockHeight,
+				transactionBody,
+				transactionHash,
+				maxFee,
+				timestamp,
+				status,
+				confirm
+			} = await TransactionService.getTransactionInfo('541B506C91003C248CF09C6FB3BC94D0A26B8197B76B2827DDE3AF3A0ED3E350');
+
+			// Assert:
+			expect(blockHeight).toEqual(undefined);
+			expect(transactionHash).toEqual(transferTransaction.transactionInfo.hash);
+			expect(maxFee).toEqual(transactionFromSDK.maxFee);
+			expect(timestamp).toEqual(0);
+			expect(transactionBody).toEqual(transactionFromSDK.transactionBody);
+			expect(status).toEqual(transactionStatus.detail.code);
+			expect(confirm).toEqual(transactionStatus.message);
+		});
 	});
 
 	describe('getTransactionList', () => {

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -10,22 +10,20 @@ describe('Transaction Service', () => {
 	describe('getTransactionInfo', () => {
 		it('returns transfer transaction with paid fee', async () => {
 			// Arrange:
-			const mockTransactionStatus = {
+			const transactionStatus = {
 				message: 'confirmed',
 				detail: {
 					code: 'Success'
 				}
 			};
 
-			const mockBlockInfo = {
-				height: 198327,
-				timestamp: 1646063763
-			};
+			const transferTransaction = TestHelper.mockTransaction({
+				height: UInt64.fromUint(198327),
+				timestamp: UInt64.fromUint(1646063763)
+			});
 
-			const mockTransferTransaction = TestHelper.mockTransaction(mockBlockInfo);
-
-			const mockCreateTransactionFromSDK = {
-				...mockTransferTransaction,
+			const transactionFromSDK = {
+				...transferTransaction,
 				deadline: '2022-02-28 17:55:31',
 				maxFee: '0.005000',
 				transactionType: 16724,
@@ -48,14 +46,11 @@ describe('Transaction Service', () => {
 				}
 			};
 
-			const getTransactionStatus = stub(TransactionService, 'getTransactionStatus');
-			getTransactionStatus.returns(Promise.resolve(mockTransactionStatus));
+			stub(TransactionService, 'getTransactionStatus').returns(Promise.resolve(transactionStatus));
 
-			const getTransaction = stub(TransactionService, 'getTransaction');
-			getTransaction.returns(Promise.resolve(mockTransferTransaction));
+			stub(TransactionService, 'getTransaction').returns(Promise.resolve(transferTransaction));
 
-			const createTransactionFromSDK = stub(TransactionService, 'createTransactionFromSDK');
-			createTransactionFromSDK.returns(Promise.resolve(mockCreateTransactionFromSDK));
+			stub(TransactionService, 'createTransactionFromSDK').returns(Promise.resolve(transactionFromSDK));
 
 			// Act:
 			const {
@@ -69,13 +64,13 @@ describe('Transaction Service', () => {
 			} = await TransactionService.getTransactionInfo('541B506C91003C248CF09C6FB3BC94D0A26B8197B76B2827DDE3AF3A0ED3E350');
 
 			// Assert:
-			expect(blockHeight).toEqual(mockTransferTransaction.transactionInfo.height);
-			expect(transactionHash).toEqual(mockTransferTransaction.transactionInfo.hash);
+			expect(blockHeight).toEqual(transferTransaction.transactionInfo.height);
+			expect(transactionHash).toEqual(transferTransaction.transactionInfo.hash);
 			expect(effectiveFee).toEqual('0.001760');
-			expect(timestamp).toEqual(mockBlockInfo.timestamp);
-			expect(status).toEqual(mockTransactionStatus.detail.code);
-			expect(confirm).toEqual(mockTransactionStatus.message);
-			expect(transactionBody).toEqual(mockCreateTransactionFromSDK.transactionBody);
+			expect(timestamp).toEqual(1646063763);
+			expect(status).toEqual(transactionStatus.detail.code);
+			expect(confirm).toEqual(transactionStatus.message);
+			expect(transactionBody).toEqual(transactionFromSDK.transactionBody);
 		});
 
 		it('returns partial transaction with max fee', async () => {

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -1,7 +1,7 @@
+import Helper from '../../src/helper';
 import { TransactionService, LockService } from '../../src/infrastructure';
 import http from '../../src/infrastructure/http';
 import TestHelper from '../TestHelper';
-import Helper from '../../src/helper';
 import { restore, stub } from 'sinon';
 import { MosaicId, UInt64, TransactionGroup } from 'symbol-sdk';
 
@@ -30,7 +30,7 @@ describe('Transaction Service', () => {
 					}
 				]
 			}
-		}
+		};
 
 		it('returns transfer transaction with paid fee', async () => {
 			// Arrange:
@@ -48,7 +48,7 @@ describe('Transaction Service', () => {
 
 			const transactionFromSDK = {
 				...transferTransaction,
-				...transferTransactionFromSDK,
+				...transferTransactionFromSDK
 			};
 
 			stub(TransactionService, 'getTransactionStatus').returns(Promise.resolve(transactionStatus));
@@ -69,9 +69,11 @@ describe('Transaction Service', () => {
 			} = await TransactionService.getTransactionInfo('541B506C91003C248CF09C6FB3BC94D0A26B8197B76B2827DDE3AF3A0ED3E350');
 
 			// Assert:
-			expect(blockHeight).toEqual(transferTransaction.transactionInfo.height);
-			expect(transactionHash).toEqual(transferTransaction.transactionInfo.hash);
-			expect(effectiveFee).toEqual(Helper.toNetworkCurrency(transferTransaction.payloadSize * transferTransaction.transactionInfo.feeMultiplier));
+			const { payloadSize, transactionInfo } = transferTransaction;
+
+			expect(blockHeight).toEqual(transactionInfo.height);
+			expect(transactionHash).toEqual(transactionInfo.hash);
+			expect(effectiveFee).toEqual(Helper.toNetworkCurrency(payloadSize * transactionInfo.feeMultiplier));
 			expect(timestamp).toEqual(1646063763);
 			expect(transactionBody).toEqual(transactionFromSDK.transactionBody);
 			expect(status).toEqual(transactionStatus.detail.code);
@@ -179,7 +181,7 @@ describe('Transaction Service', () => {
 
 			const transactionFromSDK = {
 				...transferTransaction,
-				...transferTransactionFromSDK,
+				...transferTransactionFromSDK
 			};
 
 			stub(TransactionService, 'getTransactionStatus').returns(Promise.resolve(transactionStatus));
@@ -248,7 +250,8 @@ describe('Transaction Service', () => {
 					expect(transaction).toHaveProperty('extendGraphicValue');
 
 					if (transactionGroup === TransactionGroup.Confirmed) {
-						expect(transaction.effectiveFee).toBe(Helper.toNetworkCurrency(transaction.payloadSize * transaction.transactionInfo.feeMultiplier));
+						const { payloadSize, transactionInfo } = transaction;
+						expect(transaction.effectiveFee).toBe(Helper.toNetworkCurrency(payloadSize * transactionInfo.feeMultiplier));
 						expect(transaction).not.toHaveProperty('maxFee');
 					} else {
 						expect(transaction.maxFee).toBe('1.000000');

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -1,6 +1,7 @@
 import { TransactionService, LockService } from '../../src/infrastructure';
 import http from '../../src/infrastructure/http';
 import TestHelper from '../TestHelper';
+import Helper from '../../src/helper';
 import { restore, stub } from 'sinon';
 import { MosaicId, UInt64, TransactionGroup } from 'symbol-sdk';
 
@@ -8,6 +9,29 @@ describe('Transaction Service', () => {
 	afterEach(restore);
 
 	describe('getTransactionInfo', () => {
+		const transferTransactionFromSDK = {
+			deadline: '2022-02-28 17:55:31',
+			maxFee: '0.005000',
+			transactionType: 16724,
+			transactionBody: {
+				transactionType: 16724,
+				message: {
+					type: -1,
+					payload: ''
+				},
+				recipient: 'TDCPHIHQPN6WKJJIUCOFISJCB4NULEZOS4NCQQQ',
+				mosaics: [
+					{
+						amount: '5',
+						mosaicId: '7F2D26E89342D398',
+						mosaicAliasName: [
+							'teria.revokable'
+						]
+					}
+				]
+			}
+		}
+
 		it('returns transfer transaction with paid fee', async () => {
 			// Arrange:
 			const transactionStatus = {
@@ -24,26 +48,7 @@ describe('Transaction Service', () => {
 
 			const transactionFromSDK = {
 				...transferTransaction,
-				deadline: '2022-02-28 17:55:31',
-				maxFee: '0.005000',
-				transactionType: 16724,
-				transactionBody: {
-					transactionType: 16724,
-					message: {
-						type: -1,
-						payload: ''
-					},
-					recipient: 'TDCPHIHQPN6WKJJIUCOFISJCB4NULEZOS4NCQQQ',
-					mosaics: [
-						{
-							amount: '5',
-							mosaicId: '7F2D26E89342D398',
-							mosaicAliasName: [
-								'teria.revokable'
-							]
-						}
-					]
-				}
+				...transferTransactionFromSDK,
 			};
 
 			stub(TransactionService, 'getTransactionStatus').returns(Promise.resolve(transactionStatus));
@@ -68,9 +73,9 @@ describe('Transaction Service', () => {
 			expect(transactionHash).toEqual(transferTransaction.transactionInfo.hash);
 			expect(effectiveFee).toEqual(Helper.toNetworkCurrency(transferTransaction.payloadSize * transferTransaction.transactionInfo.feeMultiplier));
 			expect(timestamp).toEqual(1646063763);
+			expect(transactionBody).toEqual(transactionFromSDK.transactionBody);
 			expect(status).toEqual(transactionStatus.detail.code);
 			expect(confirm).toEqual(transactionStatus.message);
-			expect(transactionBody).toEqual(transactionFromSDK.transactionBody);
 		});
 
 		it('returns partial transaction with max fee', async () => {
@@ -98,7 +103,6 @@ describe('Transaction Service', () => {
 					{
 						...innerTransaction,
 						deadline: '2022-02-28 17:55:31',
-						maxFee: 0,
 						transactionType: 16724,
 						transactionBody: {
 							transactionType: 16724,

--- a/__tests__/infrastructure/TransactionService.spec.js
+++ b/__tests__/infrastructure/TransactionService.spec.js
@@ -66,7 +66,7 @@ describe('Transaction Service', () => {
 			// Assert:
 			expect(blockHeight).toEqual(transferTransaction.transactionInfo.height);
 			expect(transactionHash).toEqual(transferTransaction.transactionInfo.hash);
-			expect(effectiveFee).toEqual('0.001760');
+			expect(effectiveFee).toEqual(Helper.toNetworkCurrency(transferTransaction.payloadSize * transferTransaction.transactionInfo.feeMultiplier));
 			expect(timestamp).toEqual(1646063763);
 			expect(status).toEqual(transactionStatus.detail.code);
 			expect(confirm).toEqual(transactionStatus.message);
@@ -198,7 +198,7 @@ describe('Transaction Service', () => {
 					expect(transaction).toHaveProperty('extendGraphicValue');
 
 					if (transactionGroup === TransactionGroup.Confirmed) {
-						expect(transaction.effectiveFee).toBe('0.001760');
+						expect(transaction.effectiveFee).toBe(Helper.toNetworkCurrency(transaction.payloadSize * transaction.transactionInfo.feeMultiplier));
 						expect(transaction).not.toHaveProperty('maxFee');
 					} else {
 						expect(transaction.maxFee).toBe('1.000000');

--- a/src/config/i18n/en-us.json
+++ b/src/config/i18n/en-us.json
@@ -9,7 +9,7 @@
     "relativeAmount": "Value",
     "height": "Height",
     "fee": "Fee",
-    "maxFee": "Fee",
+    "maxFee": "Max Fee",
     "totalFee": "Total Fee",
     "date": "Date",
     "deadline": "Deadline",

--- a/src/config/i18n/ko.json
+++ b/src/config/i18n/ko.json
@@ -9,7 +9,7 @@
     "relativeAmount": "값",
     "height": "높이",
     "fee": "수수료",
-    "maxFee": "수수료",
+    "maxFee": "최대 수수료",
     "totalFee": "총 수수료",
     "date": "일자",
     "deadline": "마감일",

--- a/src/config/i18n/zh.json
+++ b/src/config/i18n/zh.json
@@ -9,7 +9,7 @@
     "relativeAmount": "相对金额",
     "height": "高度",
     "fee": "费用",
-    "maxFee": "Fee",
+    "maxFee": "最大费用",
     "totalFee": "Total Fee",
     "date": "日期",
     "deadline": "截止时间",

--- a/src/config/pages/transaction-detail.json
+++ b/src/config/pages/transaction-detail.json
@@ -32,6 +32,7 @@
                     "signer",
                     "payloadSize",
                     "effectiveFee",
+                    "maxFee",
                     "signature",
                     "version"
                 ]

--- a/src/config/pages/transaction-list.json
+++ b/src/config/pages/transaction-list.json
@@ -25,7 +25,8 @@
                     "signer",
                     "recipient",
                     "extendGraphicValue",
-                    "maxFee"
+                    "maxFee",
+                    "effectiveFee"
                 ]
             }
         ]

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -118,17 +118,27 @@ class TransactionService {
   	const transactionGroup = transactionStatus.message;
   	const transaction = await this.getTransaction(hash, transactionGroup);
 
-  	const formattedTransaction = await this.createTransactionFromSDK(transaction);
+  	const {maxFee, ...formattedTransaction} = await this.createTransactionFromSDK(transaction);
 
   	const transactionInfo = {
 		  ...formattedTransaction,
 		  blockHeight: formattedTransaction.transactionInfo.height || undefined,
 		  transactionHash: formattedTransaction.transactionInfo.hash,
-		  effectiveFee: helper.toNetworkCurrency(formattedTransaction.payloadSize * formattedTransaction.transactionInfo.feeMultiplier),
 		  timestamp: formattedTransaction.transactionInfo.timestamp | null,
 		  status: transactionStatus.detail.code,
 		  confirm: transactionStatus.message
   	};
+
+  	// Display max fees if unconfirmed or partial transaction
+  	if (0 === formattedTransaction.transactionInfo.height) {
+  		Object.assign(transactionInfo, {
+  			maxFee
+  		});
+  	} else {
+  		Object.assign(transactionInfo, {
+  			effectiveFee: helper.toNetworkCurrency(formattedTransaction.payloadSize * formattedTransaction.transactionInfo.feeMultiplier)
+  		});
+  	}
 
   	return transactionInfo;
   }

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -212,8 +212,9 @@ class TransactionService {
   	return {
   		...transactions,
   		totalRecords,
-  		data: transactions.data.map(({ deadline, ...transaction }) => ({
+  		data: transactions.data.map(({ deadline, maxFee, ...transaction }) => ({
   			...transaction,
+  			effectiveFee: helper.toNetworkCurrency(transaction.payloadSize * transaction.transactionInfo.feeMultiplier),
   			age: helper.convertTimestampToDate(transaction.transactionInfo.timestamp),
   			height: transaction.transactionInfo.height,
   			transactionHash: transaction.transactionInfo.hash,


### PR DESCRIPTION
## What was the issue?
- fee displayed incorrectly in partial/unconfirmed transactions detail and listing page.

## What's the fix?
- in unconfirmed/partial transactions, it will display the max fee.
- in the confirmed transaction, it will display effective fees.
- minor refactor transaction service unit test
- added unit test

Sample:
- partial/unconfirmed 
<img width="1336" alt="Screenshot 2022-10-17 at 2 28 33 AM" src="https://user-images.githubusercontent.com/5649156/196051951-5970ec99-5a9c-4cbf-ae13-cd859129f11b.png">

<img width="591" alt="Screenshot 2022-10-17 at 2 28 45 AM" src="https://user-images.githubusercontent.com/5649156/196051947-e4757eb2-0ac1-4ed1-9cc6-46cd3fbe9d5a.png">

- confirmed
<img width="542" alt="Screenshot 2022-10-17 at 2 28 55 AM" src="https://user-images.githubusercontent.com/5649156/196051949-e52216d8-2a03-4fbd-8bf1-970598cc5c38.png">

<img width="1342" alt="Screenshot 2022-10-17 at 2 23 08 AM" src="https://user-images.githubusercontent.com/5649156/196051944-51140467-f2a5-4283-b05d-62a9d99e6d49.png">


- 