### PR TITLE
[explorer] fix: search namespace without dash

### DIFF
--- a/__tests__/store/ui.spec.js
+++ b/__tests__/store/ui.spec.js
@@ -131,25 +131,21 @@ describe('store/ui', () => {
 		});
 
 		describe('input value contain whitespace', () => {
-			const runBasicWhitespaceTests = (pageName, inputValue) => {
+			const runBasicWhitespaceTests = (pageName, inputValue, expectedResult) => {
 				it(`returns ${pageName} page`, async () => {
 					// Arrange:
-					if ('mosaic' === pageName) 
+					if ('mosaic' === pageName)
 						stub(MosaicService, 'getMosaicInfo').returns(Promise.resolve({}));
-					 else if('account' === pageName) 
+					else if('account' === pageName)
 						stub(AccountService, 'getAccountInfo').returns(Promise.resolve({}));
-					 else if ('namespace' === pageName) 
+					else if ('namespace' === pageName)
 						stub(NamespaceService, 'getNamespaceInfo').returns(Promise.resolve({}));
-					
 
 					// Act:
 					await ui.actions.search({ dispatch, rootGetters }, inputValue);
 
 					// Assert:
-					expect(dispatch).toHaveBeenNthCalledWith(1, 'openPage', {
-						pageName,
-						param: inputValue.replace(/\s/g, '')
-					});
+					expect(dispatch).toHaveBeenNthCalledWith(1, 'openPage', expectedResult);
 				});
 			};
 
@@ -181,7 +177,10 @@ describe('store/ui', () => {
 				}
 			];
 
-			inputValues.forEach(({input, pageName}) => runBasicWhitespaceTests(pageName, input));
+			inputValues.forEach(({input, pageName}) => runBasicWhitespaceTests(pageName, input, {
+				pageName,
+				param: input.replace(/\s/g, '')
+			}));
 		});
 	});
 });

--- a/__tests__/store/ui.spec.js
+++ b/__tests__/store/ui.spec.js
@@ -1,4 +1,3 @@
-import Helper from '../../src/helper';
 import { AccountService, MosaicService, NamespaceService } from '../../src/infrastructure';
 import ui from '../../src/store/ui';
 import { stub, restore } from 'sinon';
@@ -14,6 +13,21 @@ describe('store/ui', () => {
 		});
 
 		afterEach(restore);
+
+		const assertSearchNamespace = async namespaceName => {
+			// Arrange:
+			stub(NamespaceService, 'getNamespaceInfo').returns(Promise.resolve({}));
+
+			// Act:
+			await ui.actions.search({ dispatch, rootGetters }, namespaceName);
+
+			// Assert:
+			expect(dispatch).toHaveBeenCalledTimes(1);
+			expect(dispatch).toHaveBeenNthCalledWith(1, 'openPage', {
+				pageName: 'namespace',
+				param: namespaceName
+			});
+		};
 
 		it('return block page with height', async () => {
 			// Arrange:
@@ -96,23 +110,9 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return namespace page with namespace name', async () => {
-			// Arrange:
-			const namespaceName = 'symbol.xym';
+		it('return namespace page with namespace name', async () => await assertSearchNamespace('symbol.xym'));
 
-			const getNamespaceInfoStub = stub(NamespaceService, 'getNamespaceInfo');
-			getNamespaceInfoStub.returns(Promise.resolve({}));
-
-			// Act:
-			await ui.actions.search({ dispatch, rootGetters }, namespaceName);
-
-			// Assert:
-			expect(dispatch).toHaveBeenCalledTimes(1);
-			expect(dispatch).toHaveBeenNthCalledWith(1, 'openPage', {
-				pageName: 'namespace',
-				param: namespaceName
-			});
-		});
+		it('return namespace page with namespace name contain dash', async () => await assertSearchNamespace('symbol-'));
 
 		it('throw error given Nem address', async () => {
 			// Arrange:

--- a/__tests__/store/ui.spec.js
+++ b/__tests__/store/ui.spec.js
@@ -3,7 +3,7 @@ import ui from '../../src/store/ui';
 import { stub, restore } from 'sinon';
 
 describe('store/ui', () => {
-	describe('action search should', () => {
+	describe('action search', () => {
 		let dispatch;
 		let rootGetters;
 
@@ -29,7 +29,7 @@ describe('store/ui', () => {
 			});
 		};
 
-		it('return block page with height', async () => {
+		it('returns block page with height', async () => {
 			// Arrange:
 			const height = '10';
 
@@ -44,12 +44,11 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return account page with public key', async () => {
+		it('returns account page with public key', async () => {
 			// Arrange:
 			const publicKey = 'DC20B243B63246C9E75E4FB5ED236513A005454393E93C8A4CE6EDEE323C2DDB';
 
-			const getAccountInfoStub = stub(AccountService, 'getAccountInfo');
-			getAccountInfoStub.returns(Promise.resolve({}));
+			stub(AccountService, 'getAccountInfo').returns(Promise.resolve({}));
 
 			// Act:
 			await ui.actions.search({ dispatch, rootGetters }, publicKey);
@@ -62,7 +61,7 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return account page with address', async () => {
+		it('returns account page with address', async () => {
 			// Arrange:
 			const address = 'TAR5OQBKR4KSVRVZ3ZBVHNLMBZ4N4Q27WFVMJDI';
 
@@ -77,7 +76,7 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return transaction page with hash', async () => {
+		it('returns transaction page with hash', async () => {
 			// Arrange:
 			const hash = '706BBC8F95AF60B22CB38911A645D3BA24DC480FDBE18C197ACCFE0FDE0DC24D';
 
@@ -92,12 +91,11 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return mosaic page with mosaic Id', async () => {
+		it('returns mosaic page with mosaic Id', async () => {
 			// Arrange:
 			const mosaicId = '3A8416DB2D53B6C8';
 
-			const getMosaicInfoStub = stub(MosaicService, 'getMosaicInfo');
-			getMosaicInfoStub.returns(Promise.resolve({}));
+			stub(MosaicService, 'getMosaicInfo').returns(Promise.resolve({}));
 
 			// Act:
 			await ui.actions.search({ dispatch, rootGetters }, mosaicId);
@@ -110,9 +108,9 @@ describe('store/ui', () => {
 			});
 		});
 
-		it('return namespace page with namespace name', async () => await assertSearchNamespace('symbol.xym'));
+		it('returns namespace page with namespace name', async () => await assertSearchNamespace('symbol.xym'));
 
-		it('return namespace page with namespace name contain dash', async () => await assertSearchNamespace('symbol-'));
+		it('returns namespace page with namespace name contain dash', async () => await assertSearchNamespace('symbol-'));
 
 		it('throw error given Nem address', async () => {
 			// Arrange:
@@ -131,6 +129,59 @@ describe('store/ui', () => {
 			return expect(ui.actions.search({ dispatch, rootGetters }, randomText))
 				.rejects.toThrow('errorNothingFound');
 		});
-	});
 
+		describe('input value contain whitespace', () => {
+			const runBasicWhitespaceTests = (pageName, inputValue) => {
+				it(`returns ${pageName} page`, async () => {
+					// Arrange:
+					if ('mosaic' === pageName) 
+						stub(MosaicService, 'getMosaicInfo').returns(Promise.resolve({}));
+					 else if('account' === pageName) 
+						stub(AccountService, 'getAccountInfo').returns(Promise.resolve({}));
+					 else if ('namespace' === pageName) 
+						stub(NamespaceService, 'getNamespaceInfo').returns(Promise.resolve({}));
+					
+
+					// Act:
+					await ui.actions.search({ dispatch, rootGetters }, inputValue);
+
+					// Assert:
+					expect(dispatch).toHaveBeenNthCalledWith(1, 'openPage', {
+						pageName,
+						param: inputValue.replace(/\s/g, '')
+					});
+				});
+			};
+
+			// Arrange:
+			const inputValues = [
+				{
+					pageName: 'block',
+					input: ' 10 '
+				},
+				{
+					pageName: 'account',
+					input: ' DC20B243B63246C9E75E4FB5ED236513A005454393E93C8A4CE6EDEE323C2DDB '
+				},
+				{
+					pageName: 'account',
+					input: ' TAR5OQBKR4KSVRVZ3ZBVHNLMBZ4N4Q27WFVMJDI '
+				},
+				{
+					pageName: 'transaction',
+					input: ' 706BBC8F95AF60B22CB38911A645D3BA24DC480FDBE18C197ACCFE0FDE0DC24D'
+				},
+				{
+					pageName: 'mosaic',
+					input: '3A8416DB2D53B6C8 '
+				},
+				{
+					pageName: 'namespace',
+					input: 'symbol . xym '
+				}
+			];
+
+			inputValues.forEach(({input, pageName}) => runBasicWhitespaceTests(pageName, input));
+		});
+	});
 });

--- a/src/store/ui.js
+++ b/src/store/ui.js
@@ -103,7 +103,7 @@ export default {
 		search: ({ dispatch, rootGetters }, _searchString) => {
 			return new Promise(async (resolve, reject) => {
 				if (null !== _searchString && '' !== _searchString) {
-					const searchString = _searchString.replace(/\s|-/g, '');
+					const searchString = _searchString.replace(/\s/g, '');
 					if (helper.isBlockHeight(searchString)) {
 						dispatch('openPage', {
 							pageName: 'block',


### PR DESCRIPTION
## What was the issue?
- when the user searches the namespace containing `-`, it not working in explorer, the reason is that the search box is defaulted removed `-`.
- we used to removed `-` to prevent the address with a dash. 

## What's the fix?
- we will keep the `-` in the search box because the namespace allows the string contain a dash.
- we no longer use `-` in our address format (for example wallet), so it won't affect address search.