### PR TITLE
[explorer] fix: unable load peer node in page, and filter only available node in list

### DIFF
--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -366,13 +366,13 @@ const TestHelper = {
 		};
 	},
 	generateNodePeerStatus: isAvailable => {
-		return	{
+		return {
 			isAvailable,
 			lastStatusCheck: 1676809816662
 		};
 	},
 	generateNodeApiStatus: isAvailable => {
-		return	{
+		return {
 			isAvailable,
 			nodePublicKey: '4DA6FB57FA168EEBBCB68DA4DDC8DA7BCF41EC93FB22A33DF510DB0F2670F623',
 			chainHeight: 2027193,

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -364,6 +364,44 @@ const TestHelper = {
 			cosignatures,
 			innerTransactions
 		};
+	},
+	generateNodePeerStatus: isAvailable => {
+		return	{
+			isAvailable,
+			lastStatusCheck: 1676809816662
+		};
+	},
+	generateNodeApiStatus: isAvailable => {
+		return	{
+			isAvailable,
+			nodePublicKey: '4DA6FB57FA168EEBBCB68DA4DDC8DA7BCF41EC93FB22A33DF510DB0F2670F623',
+			chainHeight: 2027193,
+			finalization: {},
+			nodeStatus: {},
+			restVersion: '2.4.2',
+			restGatewayUrl: 'localhost.com'
+		};
+	},
+	nodeCommonField: {
+		version: 16777989,
+		publicKey: '016DC1622EE42EF9E4D215FA1112E89040DD7AED83007283725CE9BA550272F5',
+		networkGenerationHashSeed: '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+		port: 7900,
+		networkIdentifier: 104,
+		host: 'node.com',
+		friendlyName: 'node',
+		lastAvailable: '2023-02-19T12:36:04.524Z',
+		hostDetail: {},
+		location: '',
+		ip: '127.0.0.1',
+		organization: '',
+		as: '',
+		continent: '',
+		country: '',
+		region: '',
+		city: '',
+		district: '',
+		zip: ''
 	}
 };
 

--- a/__tests__/TestHelper.js
+++ b/__tests__/TestHelper.js
@@ -376,10 +376,19 @@ const TestHelper = {
 			isAvailable,
 			nodePublicKey: '4DA6FB57FA168EEBBCB68DA4DDC8DA7BCF41EC93FB22A33DF510DB0F2670F623',
 			chainHeight: 2027193,
-			finalization: {},
-			nodeStatus: {},
+			finalization: {
+				height: 2031992,
+				epoch: 1413,
+				point: 7,
+				hash: '6B687D9B689611C90A1094A7430E78914F22A2570C80D3E42D520EB08091A973'
+			},
+			nodeStatus: {
+				apiNode: 'up',
+				db: 'up'
+			},
 			restVersion: '2.4.2',
-			restGatewayUrl: 'localhost.com'
+			restGatewayUrl: 'localhost.com',
+			isHttpsEnabled: true
 		};
 	},
 	nodeCommonField: {

--- a/__tests__/components/widgets/NodeStatsWidget.spec.js
+++ b/__tests__/components/widgets/NodeStatsWidget.spec.js
@@ -97,15 +97,15 @@ describe('NodeStatsWidget', () => {
 		it('returns node types stats when data is present', () => {
 			assertNodeStatCounts(
 				{
-					1: 5,
-					2: 5,
-					3: 5,
-					4: 5,
-					5: 0,
-					6: 0,
+					1: 3,
+					2: 7,
+					3: 4,
+					4: 6,
+					5: 8,
+					6: 12,
 					7: 5
 				},
-				generateNodeStats([5, 5, 5, 5, 0, 0, 5])
+				generateNodeStats([3, 7, 4, 6, 8, 12, 5])
 			);
 		});
 

--- a/__tests__/components/widgets/NodeStatsWidget.spec.js
+++ b/__tests__/components/widgets/NodeStatsWidget.spec.js
@@ -1,0 +1,121 @@
+import NodeStatsWidget from '../../../src/components/widgets/NodeStatsWidget.vue';
+import { i18n } from '../../../src/config';
+import { createLocalVue, mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+const setupStoreMount = stats => {
+	const nodeModule = {
+		namespaced: true,
+		getters: {
+			nodeStats:() => stats
+		}
+	};
+
+	const uiModule = {
+		namespaced: true,
+		getters: {
+			getNameByKey: state => key => i18n.getName(key)
+		}
+	};
+
+	const store = new Vuex.Store({
+		modules: {
+			node: nodeModule,
+			ui:uiModule
+		}
+	});
+
+	const propsData = {
+		dataGetter: 'node/nodeStats'
+	};
+
+	return mount(NodeStatsWidget, {
+		store,
+		localVue,
+		propsData,
+		stubs: {
+			'b-card': true,
+			'b-container': true,
+			'b-row': true,
+			'b-col': true,
+			'b-button': true,
+			'router-link': true
+		}
+	});
+};
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('NodeStatsWidget', () => {
+	describe('nodeRoles', () => {
+		const assertNodeStatCounts = (stats, expected) => {
+			// Arrange + Act:
+			const wrapper = setupStoreMount(stats);
+
+			// Assert:
+			expect(wrapper.vm.nodeRoles).toEqual(expected);
+		};
+
+		const generateNodeStats = stats => {
+			return [
+				{
+					name: 'Total count',
+					count: stats.reduce((acc, val) => acc + val, 0)
+				},
+				{
+					name: 'Peer node',
+					count: stats[0]
+				},
+				{
+					name: 'Api node',
+					count: stats[1]
+				},
+				{
+					name: 'Peer Api node',
+					count: stats[2]
+				},
+				{
+					name: 'Voting node',
+					count: stats[3]
+				},
+				{
+					name: 'Peer Voting node',
+					count: stats[4]
+				},
+				{
+					name: 'Api Voting node',
+					count: stats[5]
+				},
+				{
+					name: 'Peer Api Voting node',
+					count: stats[6]
+				}
+			];
+		};
+
+		it('returns node types stats when data is present', () => {
+			assertNodeStatCounts(
+				{
+					1: 5,
+					2: 5,
+					3: 5,
+					4: 5,
+					5: 0,
+					6: 0,
+					7: 5
+				},
+				generateNodeStats([5, 5, 5, 5, 0, 0, 5])
+			);
+		});
+
+		it('returns node types stats with 0 count when no data is present', () => {
+			assertNodeStatCounts(
+				{},
+				generateNodeStats([0, 0, 0, 0, 0, 0, 0])
+			);
+		});
+
+		it('returns empty when data is undefined', () => assertNodeStatCounts(undefined, []));
+	});
+});

--- a/__tests__/infrastructure/NodeService.spec.js
+++ b/__tests__/infrastructure/NodeService.spec.js
@@ -1,0 +1,152 @@
+import { NodeService } from '../../src/infrastructure';
+import http from '../../src/infrastructure/http';
+import TestHelper from '../TestHelper';
+
+describe('Node Service', () => {
+	// Arrange:
+	const {
+		generateNodePeerStatus,
+		generateNodeApiStatus,
+		nodeCommonField
+	} = TestHelper;
+
+	const statisticServiceNodeResponse = [
+		{
+			roles: 1,
+			peerStatus: generateNodePeerStatus(true),
+			...nodeCommonField
+		},
+		{
+			roles: 2,
+			apiStatus: generateNodeApiStatus(false),
+			...nodeCommonField
+		},
+		{
+			roles: 3,
+			peerStatus: generateNodePeerStatus(true),
+			apiStatus: generateNodeApiStatus(false),
+			...nodeCommonField
+		},
+		{
+			roles: 3,
+			peerStatus: generateNodePeerStatus(true),
+			apiStatus: generateNodeApiStatus(true),
+			...nodeCommonField
+		},
+		{
+			roles: 5,
+			peerStatus: generateNodePeerStatus(true),
+			...nodeCommonField
+		},
+		{
+			roles: 5,
+			peerStatus: generateNodePeerStatus(false),
+			...nodeCommonField
+		},
+		{
+			roles: 7,
+			peerStatus: generateNodePeerStatus(true),
+			apiStatus: generateNodeApiStatus(true),
+			...nodeCommonField
+		}
+	];
+
+	describe('getAvailableNodes', () => {
+		it('returns available node from statistic services', async () => {
+			// Arrange:
+			http.statisticServiceRestClient = jest.fn().mockImplementation(() => {
+				return {
+					getNodes: jest.fn().mockResolvedValue(statisticServiceNodeResponse)
+				};
+			});
+
+			const expectNodeFormattedCommonField = {
+				network: 'MAINNET',
+				address: 'NDY2CXBR6SK3G7UWVXZT6YQTVJKHKFMPU74ZOYY',
+				nodePublicKey:
+					'016DC1622EE42EF9E4D215FA1112E89040DD7AED83007283725CE9BA550272F5',
+				version: '1.0.3.5'
+			};
+
+			// Act:
+			const result = await NodeService.getAvailableNodes();
+
+			// Assert:
+			expect(result).toEqual([
+				{
+					...nodeCommonField,
+					...expectNodeFormattedCommonField,
+					apiEndpoint: 'N/A',
+					roles: 'Peer node',
+					rolesRaw: 1,
+					peerStatus: generateNodePeerStatus(true)
+				},
+				{
+					...nodeCommonField,
+					...expectNodeFormattedCommonField,
+					apiEndpoint: 'localhost.com',
+					roles: 'Peer Api node',
+					rolesRaw: 3,
+					peerStatus: generateNodePeerStatus(true),
+					apiStatus: generateNodeApiStatus(true)
+				},
+				{
+					...nodeCommonField,
+					...expectNodeFormattedCommonField,
+					apiEndpoint: 'N/A',
+					roles: 'Peer Voting node',
+					rolesRaw: 5,
+					peerStatus: generateNodePeerStatus(true)
+				},
+				{
+					...nodeCommonField,
+					...expectNodeFormattedCommonField,
+					apiEndpoint: 'localhost.com',
+					roles: 'Peer Api Voting node',
+					rolesRaw: 7,
+					peerStatus: generateNodePeerStatus(true),
+					apiStatus: generateNodeApiStatus(true)
+				}
+			]);
+		});
+
+		it('throws error when statistic services fail response', async () => {
+			// Arrange:
+			const error = new Error('Statistics service getNode error');
+
+			http.statisticServiceRestClient = jest.fn().mockImplementation(() => {
+				return {
+					getNodes: jest.fn().mockRejectedValue(error)
+				};
+			});
+
+			// Act + Assert:
+			await expect(NodeService.getAvailableNodes()).rejects.toThrow(error);
+		});
+	});
+
+	describe('getNodeStats', () => {
+		it('return nodes count with 7 types of roles', async () => {
+			// Arrange:
+			http.statisticServiceRestClient = jest.fn().mockImplementation(() => {
+				return {
+					getNodes: jest.fn().mockResolvedValue(statisticServiceNodeResponse)
+				};
+			});
+
+			// Act:
+			const nodeStats = await NodeService.getNodeStats();
+
+			// Assert:
+			expect(nodeStats).toEqual({
+				1: 1,
+				2: 0,
+				3: 1,
+				4: 0,
+				5: 1,
+				6: 0,
+				7: 1
+			});
+		});
+	});
+});

--- a/__tests__/infrastructure/NodeService.spec.js
+++ b/__tests__/infrastructure/NodeService.spec.js
@@ -177,8 +177,7 @@ describe('Node Service', () => {
 			finalizedHeight: 2031992,
 			finalizationEpoch: 1413,
 			finalizationPoint: 7,
-			finalizedHash:
-				'6B687D9B689611C90A1094A7430E78914F22A2570C80D3E42D520EB08091A973',
+			finalizedHash: '6B687D9B689611C90A1094A7430E78914F22A2570C80D3E42D520EB08091A973',
 			lastStatusCheck: '2023-02-21 00:00:00'
 		};
 

--- a/__tests__/infrastructure/NodeService.spec.js
+++ b/__tests__/infrastructure/NodeService.spec.js
@@ -34,6 +34,12 @@ describe('Node Service', () => {
 			...nodeCommonField
 		},
 		{
+			roles: 3,
+			peerStatus: generateNodePeerStatus(false),
+			apiStatus: generateNodeApiStatus(false),
+			...nodeCommonField
+		},
+		{
 			roles: 5,
 			peerStatus: generateNodePeerStatus(true),
 			...nodeCommonField
@@ -104,6 +110,15 @@ describe('Node Service', () => {
 					roles: 'Peer Api node',
 					rolesRaw: 3,
 					peerStatus: generateNodePeerStatus(true),
+					apiStatus: generateNodeApiStatus(false)
+				},
+				{
+					...nodeCommonField,
+					...expectNodeFormattedCommonField,
+					apiEndpoint: 'localhost.com',
+					roles: 'Peer Api node',
+					rolesRaw: 3,
+					peerStatus: generateNodePeerStatus(true),
 					apiStatus: generateNodeApiStatus(true)
 				},
 				{
@@ -145,7 +160,7 @@ describe('Node Service', () => {
 			expect(nodeStats).toEqual({
 				1: 1,
 				2: 0,
-				3: 1,
+				3: 2,
 				4: 0,
 				5: 1,
 				6: 0,
@@ -199,7 +214,7 @@ describe('Node Service', () => {
 			expect(peerStatus).toEqual(expectedResult.peerStatus);
 		};
 
-		it('returns api node status and chain info when api status is present', async () => {
+		it('returns peer node status when peer status is present', async () => {
 			await assertNodeStatus(statisticServiceNodeResponse[0], {
 				peerStatus: expectedPeerStatus,
 				apiStatus: {},
@@ -207,7 +222,7 @@ describe('Node Service', () => {
 			});
 		});
 
-		it('returns peer node status when peer status is present', async () => {
+		it('returns api node status and chain info when api status is present', async () => {
 			await assertNodeStatus(statisticServiceNodeResponse[1], {
 				peerStatus: {},
 				apiStatus: expectedAPIStatus,
@@ -215,7 +230,7 @@ describe('Node Service', () => {
 			});
 		});
 
-		it('returns api and peer node status when both status is present', async () => {
+		it('returns chain info, api and peer node status when both status is present', async () => {
 			await assertNodeStatus(statisticServiceNodeResponse[2], {
 				peerStatus: expectedPeerStatus,
 				apiStatus: expectedAPIStatus,

--- a/src/components/widgets/NodeStatsWidget.vue
+++ b/src/components/widgets/NodeStatsWidget.vue
@@ -38,10 +38,6 @@
 import Card from '@/components/containers/Card.vue';
 import ButtonMore from '@/components/controls/ButtonMore.vue';
 import Constants from '../../config/constants';
-import IconOrange from '../../styles/img/connector_orange.png';
-import IconBlue from '../../styles/img/connector_blue.png';
-import IconGreen from '../../styles/img/connector_green.png';
-import IconPink from '../../styles/img/connector_pink.png';
 
 export default {
 	components: {
@@ -70,7 +66,7 @@ export default {
 		},
 
 		nodeRoles () {
-			const data = this.data?.nodeTypes;
+			const data = this.data;
 
 			if (!data)
 				return [];
@@ -78,50 +74,35 @@ export default {
 			return [
 				{
 					name: this.getNameByKey('allNodes'),
-					count: Array.from(Array(8).keys()).reduce((acc, val) => acc + (data[val] || 0)),
-					icon: IconBlue
+					count: Array.from(Array(8).keys()).reduce((acc, val) => acc + (data[val] || 0))
 				},
 				{
 					name: Constants.RoleType[1],
-					count: data[1] || 0,
-					icon: IconBlue,
-					color: 'blue'
+					count: data[1] || 0
 				},
 				{
 					name: Constants.RoleType[2],
-					count: data[2] || 0,
-					icon: IconPink,
-					color: 'pink'
+					count: data[2] || 0
 				},
 				{
 					name: Constants.RoleType[3],
-					count: data[3] || 0,
-					icon: IconPink,
-					color: 'pink'
+					count: data[3] || 0
 				},
 				{
 					name: Constants.RoleType[4],
-					count: data[4] || 0,
-					icon: IconGreen,
-					color: 'green'
+					count: data[4] || 0
 				},
 				{
 					name: Constants.RoleType[5],
-					count: data[5] || 0,
-					icon: IconGreen,
-					color: 'green'
+					count: data[5] || 0
 				},
 				{
 					name: Constants.RoleType[6],
-					count: data[6] || 0,
-					icon: IconOrange,
-					color: 'orange'
+					count: data[6] || 0
 				},
 				{
 					name: Constants.RoleType[7],
-					count: data[7] || 0,
-					icon: IconOrange,
-					color: 'orange'
+					count: data[7] || 0
 				}
 			];
 		},

--- a/src/config/pages/node-detail.json
+++ b/src/config/pages/node-detail.json
@@ -84,6 +84,20 @@
 				]
 			},
 			{
+				"layoutOptions": "adaptive",
+				"type": "CardTable",
+				"title": "nodePeerStatusTitle",
+				"managerGetter": "node/info",
+				"dataGetter": "node/peerStatus",
+				"errorMessage": "nodeDetailError",
+				"pagination": "none",
+				"hideEmptyData": true,
+				"fields": [
+					"connectionStatus",
+					"lastStatusCheck"
+				]
+			},
+			{
 				"layoutOptions": "full-width",
 				"type": "CardTable",
 				"title": "nodeChainInfoTitle",

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -46,24 +46,6 @@ class NodeService {
 	};
 
 	/**
-	 * Get Node Peers from symbol SDK.
-	 * @returns {array} NodeInfo[]
-	 */
-	static getNodePeers = async () => {
-		let nodePeers = [];
-
-		try {
-			nodePeers = await http.statisticServiceRestClient().getNodes();
-		} catch (e) {
-			console.error('Statistics service getNodes error: ', e);
-		}
-
-		return nodePeers
-			.map(nodeInfo => this.formatNodeInfo(nodeInfo))
-			.sort((a, b) => a.friendlyName.localeCompare(b.friendlyName));
-	};
-
-	/**
 	 * Get node health status by endpoint.
 	 * @param {string} currentUrl api-node endpoint such as http:localhost:3000
 	 * @returns {boolean} boolean
@@ -106,15 +88,40 @@ class NodeService {
 	});
 
 	/**
-	 * Format Node Peers dataset into Vue Component.
+	 * Get available node list from statistic service.
+	 * @returns {array} NodeInfo[]
+	 */
+	static getAvailableNodes = async () => {
+		try {
+			const nodePeers = await http.statisticServiceRestClient().getNodes();
+
+			return nodePeers
+				.filter(({ apiStatus, roles, peerStatus }) => {
+					if (1 === roles || 4 === roles || 5 === roles)
+						return peerStatus?.isAvailable;
+					else if (3 === roles || 6 === roles || 7 === roles)
+						return apiStatus?.isAvailable && peerStatus?.isAvailable;
+					else 
+						return apiStatus?.isAvailable;
+				})
+				.map(nodeInfo => this.formatNodeInfo(nodeInfo))
+				.sort((a, b) => a.friendlyName.localeCompare(b.friendlyName));
+		} catch (e) {
+			console.error(e);
+			throw Error('Statistics service getNode error');
+		}
+	};
+
+	/**
+	 * Format Available Node Peers dataset into Vue Component.
 	 * @param {string} filter role filter.
 	 * @returns {object} Node peers object for Vue component.
 	 */
-	static getNodePeerList = async filter => {
-		let nodePeers = await this.getNodePeers();
+	static getAvailableNodeList = async filter => {
+		const availableNodes = await this.getAvailableNodes();
 
 		return {
-			data: nodePeers
+			data: availableNodes
 				.filter(el => !filter.rolesRaw || el.rolesRaw === filter.rolesRaw)
 				.map(el => {
 					let node = {
@@ -219,11 +226,19 @@ class NodeService {
 	};
 
 	static getNodeStats = async () => {
-		try {
-			return await http.statisticServiceRestClient().getNodeStats();
-		} catch (e) {
-			throw Error('Statistics service getNodeStats error: ', e);
-		}
+		const availableNodes = await this.getAvailableNodes();
+
+		let nodeTypes = {};
+
+		// 7 types of roles
+		Array.from(Array(8).keys()).map(index => {
+			Object.assign(nodeTypes, {
+				[index + 1]: availableNodes.filter(node => node.rolesRaw === index + 1)
+					.length
+			});
+		});
+
+		return nodeTypes;
 	};
 
 	static getNodeHeightStats = async () => {
@@ -252,7 +267,7 @@ class NodeService {
 	};
 
 	static getNodeListCSV = async filter => {
-		const nodes = await this.getNodePeerList(filter);
+		const nodes = await this.getActiveNodeList(filter);
 
 		const formattedData = nodes.data.map((node, index) => ({
 			no: index + 1,

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -100,7 +100,7 @@ class NodeService {
 					if (1 === roles || 4 === roles || 5 === roles)
 						return peerStatus?.isAvailable;
 					else if (3 === roles || 6 === roles || 7 === roles)
-						return apiStatus?.isAvailable && peerStatus?.isAvailable;
+						return apiStatus?.isAvailable || peerStatus?.isAvailable;
 					else
 						return apiStatus?.isAvailable;
 				})

--- a/src/store/chain.js
+++ b/src/store/chain.js
@@ -138,7 +138,7 @@ export default {
 			// commit('setMarketData', { marketData, graphData });
 
 			if (nodeStats)
-				commit('setNodeStats', nodeStats.nodeTypes);
+				commit('setNodeStats', nodeStats);
 		},
 
 		async getChainInfo ({ commit }) {

--- a/src/store/node.js
+++ b/src/store/node.js
@@ -31,7 +31,7 @@ import { NodeService, StatisticService } from '../infrastructure';
 const managers = [
 	new Pagination({
 		name: 'timeline',
-		fetchFunction: (pageInfo, filterValue) => NodeService.getNodePeerList(filterValue),
+		fetchFunction: (pageInfo, filterValue) => NodeService.getAvailableNodeList(filterValue),
 		filter: filters.nodeRoles
 	}),
 	new DataSet(


### PR DESCRIPTION
## What was the issue?
- peer/voting node unable load in node page.
- node listing contains stale nodes, it needs to filter out.

## What's the fix?
- filter all the stale nodes, for the node list.
- refactor on getNodeStats, all stats will be calculated based on the available node list.
- refactor on getNodeInfo to fix unable load peer/voting node in page.
- add unit test