### PR TITLE
[explorer] fix: account listing default display rich list

### DIFF
--- a/src/config/filters.js
+++ b/src/config/filters.js
@@ -182,17 +182,17 @@ export const transaction = [
 
 export const account = [
 	{
-		label: 'Recent',
-		icon: 'mdi-clock-outline',
-		value: {}
-	},
-	{
 		label: 'Rich List',
 		icon: 'mdi-cash',
 		value: {
 			orderBy: AccountOrderBy.Balance,
 			mosaicId: ''
 		}
+	},
+	{
+		label: 'Recent',
+		icon: 'mdi-clock-outline',
+		value: {}
 	}
 ];
 


### PR DESCRIPTION
## What was the issue?
- account listing page default displays `recent`, it's not useful for the user.
- we decide to switch to a `rich` list as default.

## What's the fix?
- account listing page will display rich list as default