### PR TITLE
[explorer] fix: remove address hyphens in account balance widget

### DIFF
--- a/__tests__/store/account.spec.js
+++ b/__tests__/store/account.spec.js
@@ -1,0 +1,38 @@
+import account from '../../src/store/account';
+
+describe('store/account', () => {
+	describe('balanceWidget getter', () => {
+		const runBasicAddressTests = (currentAccountAddress, expectedAddress) => {
+			// Arrange:
+			const state = {
+				currentAccountAddress
+			};
+
+			const getters = {
+				OwnedMosaic: {
+					data: []
+				},
+				info: {}
+			};
+
+			// Act:
+			const result = account.getters.balanceWidget(state, getters);
+
+			// Assert:
+			expect(result).toEqual({
+				address: expectedAddress,
+				mosaic: undefined,
+				alias: undefined
+			});
+
+		};
+
+		it('returns plain address given current account in hyphens', () => {
+			runBasicAddressTests('TCWXK7-ZZW7WG-EKSJ5A-OADFEX-MWIZOM-KFBCLA-LPY', 'TCWXK7ZZW7WGEKSJ5AOADFEXMWIZOMKFBCLALPY');
+		});
+
+		it('returns empty address if no current account', () => {
+			runBasicAddressTests(undefined, '');
+		});
+	});
+});

--- a/src/store/account.js
+++ b/src/store/account.js
@@ -169,7 +169,7 @@ export default {
 		getCurrentAccountAddress: state => state.currentAccountAddress,
 		balanceWidget: (state, getters) => ({
 			address: state.currentAccountAddress
-				? Address.createFromRawAddress(state.currentAccountAddress).pretty()
+				? Address.createFromRawAddress(state.currentAccountAddress).plain()
 				: '',
 			mosaic: getters.OwnedMosaic?.data[0],
 			alias:


### PR DESCRIPTION
## What was the issue?
- search address hyphens are not working.

## What's the fix?
- Removed address hyphens in the account balance widget, as iirc we are no longer using address hyphens in the desktop wallet. So it's useless we have address hyphens in explorer.