### PR TITLE
[explorer] fix: container overflow issue in account balance widget

### DIFF
--- a/src/components/widgets/AccountBalanceWidget.vue
+++ b/src/components/widgets/AccountBalanceWidget.vue
@@ -172,6 +172,7 @@ export default {
                 line-height: 1.75rem;
                 margin: 0 0 33.2px;
                 max-width: 100%;
+                word-break: break-word;
             }
         }
 


### PR DESCRIPTION
problem: The account balance widget having an overflow issue when in mobile view.
solution: added CSS `word-break` in to address style 

<img width="384" alt="image" src="https://github.com/symbol/explorer/assets/5649156/68e8de24-32d5-489c-a5de-12b55c107648">


reported: 
https://discord.com/channels/856325968096133191/885391953498353714/1144861152736710728
https://twitter.com/NA5GGYbQ9Nm0iLm/status/1699413399183015968