### PR TITLE
[explorer] fix: Expired mosaic namespace.

### DIFF
--- a/__tests__/config/jest.setup.js
+++ b/__tests__/config/jest.setup.js
@@ -2,6 +2,8 @@ import { TextDecoder, TextEncoder } from 'util';
 
 /* Mock init http */
 jest.mock('../../src/infrastructure/http', () => {
+	const { Address } = require('symbol-sdk');
+
 	return {
 		networkType: 152,
 		epochAdjustment: 1615853185,
@@ -17,7 +19,8 @@ jest.mock('../../src/infrastructure/http', () => {
 			NetworkType: 152,
 			NemsisTimestamp: 1637848847,
 			NamespaceGraceDuration: 2880,
-			TotalChainImportance: 7842928625000000
+			TotalChainImportance: 7842928625000000,
+			MosaicRentalSinkAddress: Address.createFromRawAddress('TATYW7IJN2TDBINTESRU66HHS5HMC4YVW7GGDRA')
 		},
 		nativeNamespaces: [
 			{

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -433,18 +433,5 @@ describe('Helper', () => {
 			expect(mosaicInfos).toStrictEqual(mockMosaicInfos);
 			expect(mosaicNames).toStrictEqual(mockMosaicNames);
 		});
-
-		it('returns empty when transactions empty', async () => {
-			// Arrange:
-			const transactions = {};
-
-			// Act:
-			const {mosaicInfos, mosaicNames, unresolvedMosaicsMap} = await Helper.getTransactionMosaicInfoAndNamespace(transactions);
-
-			// Assert:
-			expect(mosaicInfos).toStrictEqual([]);
-			expect(mosaicNames).toStrictEqual([]);
-			expect(unresolvedMosaicsMap).toStrictEqual({});
-		});
 	});
 });

--- a/__tests__/helper.spec.js
+++ b/__tests__/helper.spec.js
@@ -1,6 +1,6 @@
 import TestHelper from './TestHelper';
 import Helper from '../src/helper';
-import { MosaicService, NamespaceService } from '../src/infrastructure';
+import { MosaicService, NamespaceService, ReceiptService } from '../src/infrastructure';
 import http from '../src/infrastructure/http';
 import { restore, stub } from 'sinon';
 import { Mosaic, MosaicId, NamespaceId, NamespaceName, UInt64 } from 'symbol-sdk';
@@ -219,6 +219,44 @@ describe('Helper', () => {
 			expect(result).toStrictEqual(new MosaicId(mockTestMosaic.idHex));
 			expect(stubGetLinkedMosaicId.callCount).toBe(1);
 		});
+
+		it('returns mosaic id and called mosaic statement query', async () => {
+			// Arrange:
+			const mockNamespaceId = new NamespaceId(mockTestMosaic.namespaceName);
+
+			const stubSearchMosaicResolutionStatements = jest.spyOn(ReceiptService, 'searchMosaicResolutionStatements')
+				.mockReturnValue(Promise.resolve({
+					data: [{
+						height: UInt64.fromUint(10),
+						mosaicResolutionEntries: ['22D2D90A27738AA0'],
+						resolutionEntries: [
+							{
+								resolved: new MosaicId('22D2D90A27738AA0'),
+								source: {
+									primaryId: 0,
+									secondaryId: 0
+								}
+							}
+						],
+						resolutionType: 'Mosaic',
+						unresolved: 'C6D6C5A3883DF4F4'
+					}]
+				}));
+
+			// Act:
+			const result = await Helper.resolveMosaicId(mockNamespaceId, {
+				height: UInt64.fromUint(10),
+				primaryId: 1,
+				secondaryId: 0
+			});
+
+			// Assert:
+			expect(result).toStrictEqual(new MosaicId('22D2D90A27738AA0'));
+			expect(stubGetLinkedMosaicId.callCount).toBe(0);
+			expect(stubSearchMosaicResolutionStatements).toHaveBeenCalledWith({
+				height: UInt64.fromUint(10)
+			});
+		});
 	});
 
 	describe('getNetworkCurrencyBalance', () => {
@@ -275,21 +313,19 @@ describe('Helper', () => {
 	describe('getTransactionMosaicInfoAndNamespace', () => {
 		it('returns mosaics mapping, empty mosaic info and namespace when transaction included network mosaic', async () => {
 			// Arrange:
-			const mockTransactions = [
-				{
-					...TestHelper.mockTransaction({
-						height: 1,
-						timestamp: 10
-					}),
-					mosaics: [
-						new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(20)),
-						new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1))
-					]
-				}
-			];
+			const mockTransactions = {
+				...TestHelper.mockTransaction({
+					height: 1,
+					timestamp: 10
+				}),
+				mosaics: [
+					new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(20)),
+					new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1))
+				]
+			};
 
 			// Act:
-			const { unresolvedMosaicsMap, mosaicInfos, mosaicNames} = await Helper.getTransactionMosaicInfoAndNamespace(mockTransactions);
+			const { unresolvedMosaicsMap, mosaicInfos, mosaicNames } = await Helper.getTransactionMosaicInfoAndNamespace(mockTransactions);
 
 			// Assert:
 			expect(unresolvedMosaicsMap).toStrictEqual({
@@ -302,27 +338,33 @@ describe('Helper', () => {
 
 		it('returns mosaics mapping, mosaic info and namespace when transaction exits', async () => {
 			// Arrange:
-			const mockTransactions = [
-				{
-					...TestHelper.mockTransaction({
-						height: 1,
-						timestamp: 10
-					}),
-					mosaics: [
-						new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(20)),
-						new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1))
-					]
+			const mockAggregateTransaction = {
+				transactionInfo: {
+					height: 10,
+					index: 1
 				},
-				TestHelper.mockLockFundsTransaction(),
-				TestHelper.mockMosaicSupplyRevocationTransaction(new Mosaic(
-					new MosaicId(mockTestMosaic.idHex),
-					UInt64.fromUint(1)
-				)),
-				TestHelper.mockSecretLockTransaction(new Mosaic(
-					new NamespaceId(mockTestSecretLockMosaic.namespaceName),
-					UInt64.fromUint(20)
-				))
-			];
+				innerTransactions: [
+					{
+						...TestHelper.mockTransaction({
+							height: 1,
+							timestamp: 10
+						}),
+						mosaics: [
+							new Mosaic(new NamespaceId(http.networkCurrency.namespaceName), UInt64.fromUint(20)),
+							new Mosaic(new MosaicId(http.networkCurrency.mosaicId), UInt64.fromUint(1))
+						]
+					},
+					TestHelper.mockLockFundsTransaction(),
+					TestHelper.mockMosaicSupplyRevocationTransaction(new Mosaic(
+						new MosaicId(mockTestMosaic.idHex),
+						UInt64.fromUint(1)
+					)),
+					TestHelper.mockSecretLockTransaction(new Mosaic(
+						new NamespaceId(mockTestSecretLockMosaic.namespaceName),
+						UInt64.fromUint(20)
+					))
+				]
+			};
 
 			const mockMosaicInfos = [
 				TestHelper.mockMosaicInfo(mockTestMosaic.idHex, 'TC46AZWUIZYZ2WVGLVEZYNZHSIFAD3AFDPUJMEA', 10, 0),
@@ -359,9 +401,27 @@ describe('Helper', () => {
 				.resolves(Promise.resolve(mockMosaicNames));
 
 			stub(NamespaceService, 'getLinkedMosaicId').resolves(Promise.resolve(new MosaicId(mockTestSecretLockMosaic.idHex)));
+			stub(ReceiptService, 'searchMosaicResolutionStatements').resolves(Promise.resolve({
+				data: [{
+					height: UInt64.fromUint(10),
+					mosaicResolutionEntries: ['22D2D90A27738AA0'],
+					resolutionEntries: [
+						{
+							resolved: new MosaicId('22D2D90A27738AA0'),
+							source: {
+								primaryId: 1,
+								secondaryId: 2
+							}
+						}
+					],
+					resolutionType: 'Mosaic',
+					unresolved: 'DEBBC3DA600F2B48'
+				}]
+			}));
 
 			// Act:
-			const { unresolvedMosaicsMap, mosaicInfos, mosaicNames} = await Helper.getTransactionMosaicInfoAndNamespace(mockTransactions);
+			const { unresolvedMosaicsMap, mosaicInfos, mosaicNames } =
+				await Helper.getTransactionMosaicInfoAndNamespace(mockAggregateTransaction);
 
 			// Assert:
 			expect(unresolvedMosaicsMap).toStrictEqual({
@@ -376,7 +436,7 @@ describe('Helper', () => {
 
 		it('returns empty when transactions empty', async () => {
 			// Arrange:
-			const transactions = [];
+			const transactions = {};
 
 			// Act:
 			const {mosaicInfos, mosaicNames, unresolvedMosaicsMap} = await Helper.getTransactionMosaicInfoAndNamespace(transactions);

--- a/src/helper.js
+++ b/src/helper.js
@@ -823,6 +823,7 @@ class helper {
 			case TransactionType.MOSAIC_METADATA:
 				addUnresolvedMosaic(transaction.targetMosaicId, transactionLocation);
 				break;
+			case TransactionType.MOSAIC_ADDRESS_RESTRICTION:
 			case TransactionType.MOSAIC_DEFINITION:
 			case TransactionType.MOSAIC_SUPPLY_CHANGE:
 				addUnresolvedMosaic(transaction.mosaicId, transactionLocation);

--- a/src/helper.js
+++ b/src/helper.js
@@ -590,6 +590,8 @@ class helper {
 				for (const entry of statement.resolutionEntries) {
 					if (isReceiptSourceLessThanEqual(entry.source, transactionLocation))
 						return entry.resolved;
+					else
+						throw new Error('Failed to resolve mosaic id');
 				}
 			}
 		}

--- a/src/helper.js
+++ b/src/helper.js
@@ -562,16 +562,37 @@ class helper {
 	/**
 	 * To resolved unresolvedMosaicId.
 	 * @param {NamespaceId | MosaicId} unresolvedMosaicId - NamespaceId | MosaicId
+	 * @param {object | undefined} transactionLocation Location of transaction for which to perform the resolution.
 	 * @returns {MosaicId} MosaicId
 	 */
-	static resolveMosaicId = async unresolvedMosaicId => {
-		if (!(unresolvedMosaicId instanceof NamespaceId))
+	static resolveMosaicId = async (unresolvedMosaicId, transactionLocation = undefined) => {
+		if (0n === (BigInt(`0x${unresolvedMosaicId.id.toHex()}`) & (1n << 63n)))
 			return unresolvedMosaicId;
 
 		if (unresolvedMosaicId.id.toHex() === http.networkCurrency.namespaceId)
 			return new MosaicId(http.networkCurrency.mosaicId);
 
-		return await NamespaceService.getLinkedMosaicId(unresolvedMosaicId);
+		if (!transactionLocation)
+			return await NamespaceService.getLinkedMosaicId(unresolvedMosaicId);
+
+		const searchCriteria = {
+			height: UInt64.fromUint(transactionLocation.height)
+		};
+
+		const mosaicResolutionStatements =
+			await ReceiptService.searchMosaicResolutionStatements(searchCriteria);
+
+		const isReceiptSourceLessThanEqual = (lhs, rhs) =>
+			lhs.primaryId < rhs.primaryId || (lhs.primaryId === rhs.primaryId && lhs.secondaryId <= rhs.secondaryId);
+
+		for (const statement of mosaicResolutionStatements.data) {
+			if (statement.unresolved === unresolvedMosaicId.id.toHex()) {
+				for (const entry of statement.resolutionEntries) {
+					if (isReceiptSourceLessThanEqual(entry.source, transactionLocation))
+						return entry.resolved;
+				}
+			}
+		}
 	};
 
 	/**
@@ -771,22 +792,65 @@ class helper {
 		return 1 === pageNumber ? 0 : (pageNumber - 1) * pageSize;
 	};
 
-	static getTransactionMosaicInfoAndNamespace = async transactions => {
+	static getTransactionMosaicInfoAndNamespace = async transactionObject => {
 		const unresolvedMosaics = [];
 
-		// collect unresolved mosaics from transactions
-		transactions.map(transactionDTO => {
-			switch (transactionDTO.type) {
+		const makeTransactionLocation = (transactionInfo, secondaryId = undefined) => {
+			if (!transactionInfo?.height)
+				return undefined;
+
+			return {
+				height: transactionInfo.height,
+				primaryId: transactionInfo.index + 1,
+				secondaryId: undefined === secondaryId ? 0 : secondaryId
+			};
+		};
+
+		const addUnresolvedMosaic = (mosaicId, transactionLocation) => {
+			unresolvedMosaics.push({
+				mosaicId,
+				transactionLocation
+			});
+		};
+
+		const processTransaction = (transaction, transactionLocation) => {
+			switch (transaction.type) {
 			case TransactionType.TRANSFER:
-				unresolvedMosaics.push(...transactionDTO.mosaics);
-				return;
+				transaction.mosaics.forEach(mosaic => {
+					addUnresolvedMosaic(mosaic.id, transactionLocation);
+				});
+				break;
+			case TransactionType.MOSAIC_METADATA:
+				addUnresolvedMosaic(transaction.targetMosaicId, transactionLocation);
+				break;
+			case TransactionType.MOSAIC_DEFINITION:
+			case TransactionType.MOSAIC_SUPPLY_CHANGE:
+				addUnresolvedMosaic(transaction.mosaicId, transactionLocation);
+				break;
 			case TransactionType.MOSAIC_SUPPLY_REVOCATION:
 			case TransactionType.HASH_LOCK:
 			case TransactionType.SECRET_LOCK:
-				unresolvedMosaics.push(transactionDTO.mosaic);
-				return;
+				addUnresolvedMosaic(transaction.mosaic.id, transactionLocation);
+				break;
 			}
-		});
+		};
+
+		if (transactionObject.innerTransactions) {
+			transactionObject.innerTransactions.forEach(innerTx => {
+				processTransaction(
+					innerTx,
+					makeTransactionLocation(
+						transactionObject.transactionInfo,
+						innerTx.transactionInfo.index + 1
+					)
+				);
+			});
+		} else {
+			processTransaction(
+				transactionObject,
+				makeTransactionLocation(transactionObject.transactionInfo)
+			);
+		}
 
 		return await helper.getMosaicInfoAndNamespace(unresolvedMosaics);
 	};
@@ -795,17 +859,16 @@ class helper {
 		const unresolvedMosaicsMap = {};
 
 		// create resolved mosaic mapping
-		const resolvedMosaics = await Promise.all(unresolvedMosaics.map(async mosaic => {
-			const resolvedMosaicId = await helper.resolveMosaicId(mosaic.id);
+		const resolvedMosaics = await Promise.all(unresolvedMosaics.map(async ({mosaicId, transactionLocation}) => {
+			const resolvedMosaicId = await helper.resolveMosaicId(mosaicId, transactionLocation);
 
-			unresolvedMosaicsMap[mosaic.id.toHex()] = resolvedMosaicId.toHex();
+			unresolvedMosaicsMap[mosaicId.toHex()] = resolvedMosaicId.toHex();
 
 			return resolvedMosaicId;
 		}));
 
 		// skip networkCurrency mosaic
 		const resolvedMosaicIds = resolvedMosaics
-			.map(mosaic => mosaic.id)
 			.filter(mosaicId => mosaicId.toHex() !== http.networkCurrency.mosaicId);
 
 		// filter duplicated mosaic id

--- a/src/helper.js
+++ b/src/helper.js
@@ -795,16 +795,11 @@ class helper {
 	static getTransactionMosaicInfoAndNamespace = async transactionObject => {
 		const unresolvedMosaics = [];
 
-		const makeTransactionLocation = (transactionInfo, secondaryId = undefined) => {
-			if (!transactionInfo?.height)
-				return undefined;
-
-			return {
-				height: transactionInfo.height,
-				primaryId: transactionInfo.index + 1,
-				secondaryId: undefined === secondaryId ? 0 : secondaryId
-			};
-		};
+		const makeTransactionLocation = (transactionInfo, secondaryId = undefined) => ({
+			height: transactionInfo.height,
+			primaryId: transactionInfo.index + 1,
+			secondaryId: undefined === secondaryId ? 0 : secondaryId
+		});
 
 		const addUnresolvedMosaic = (mosaicId, transactionLocation) => {
 			unresolvedMosaics.push({

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -511,7 +511,10 @@ class AccountService {
 
 		const accountSecretLocks = await LockService.searchSecretLocks(searchCriteria);
 
-		const mosaics = accountSecretLocks.data.map(secretlock => new Mosaic(secretlock.mosaicId, secretlock.amount));
+		const mosaics = accountSecretLocks.data.map(secretlock => ({
+			mosaicId: secretlock.mosaicId,
+			transactionLocation: undefined
+		}));
 
 		const { mosaicInfos, mosaicNames, unresolvedMosaicsMap } =
 			await helper.getMosaicInfoAndNamespace(mosaics);

--- a/src/infrastructure/ReceiptExtractor.js
+++ b/src/infrastructure/ReceiptExtractor.js
@@ -6,7 +6,10 @@ class ReceiptExtractor {
 	static balanceChangeReceipt = async transactionStatement => {
 		let balanceChangeReceipt = [];
 
-		const mosaics = transactionStatement.map(statement => new Mosaic(statement.mosaicId, statement.amount));
+		const mosaics = transactionStatement.map(statement => ({
+			mosaicId: statement.mosaicId,
+			transactionLocation: undefined
+		}));
 
 		const { mosaicInfos, mosaicNames, unresolvedMosaicsMap } =
 			await helper.getMosaicInfoAndNamespace(mosaics);

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -681,9 +681,13 @@ class TransactionService {
 		case TransactionType.MOSAIC_ALIAS:
 			return CreateTransaction.mosaicAlias(transactionObj);
 		case TransactionType.MOSAIC_DEFINITION:
-			return CreateTransaction.mosaicDefinition(transactionObj);
+			return CreateTransaction.mosaicDefinition(transactionObj, {
+				unresolvedMosaicsMap
+			});
 		case TransactionType.MOSAIC_SUPPLY_CHANGE:
-			return CreateTransaction.mosaicSupplyChange(transactionObj);
+			return CreateTransaction.mosaicSupplyChange(transactionObj, {
+				unresolvedMosaicsMap
+			});
 		case TransactionType.MOSAIC_SUPPLY_REVOCATION:
 			return CreateTransaction.mosaicSupplyRevocation(transactionObj, {
 				mosaicInfos,
@@ -713,13 +717,19 @@ class TransactionService {
 		case TransactionType.ACCOUNT_OPERATION_RESTRICTION:
 			return CreateTransaction.accountOperationRestriction(transactionObj);
 		case TransactionType.MOSAIC_ADDRESS_RESTRICTION:
-			return CreateTransaction.mosaicAddressRestriction(transactionObj);
+			return CreateTransaction.mosaicAddressRestriction(transactionObj, {
+				mosaicNames,
+				unresolvedMosaicsMap
+			});
 		case TransactionType.MOSAIC_GLOBAL_RESTRICTION:
 			return CreateTransaction.mosaicGlobalRestriction(transactionObj);
 		case TransactionType.ACCOUNT_METADATA:
 			return CreateTransaction.accountMetadata(transactionObj);
 		case TransactionType.MOSAIC_METADATA:
-			return CreateTransaction.mosaicMetadata(transactionObj);
+			return CreateTransaction.mosaicMetadata(transactionObj, {
+				mosaicNames,
+				unresolvedMosaicsMap
+			});
 		case TransactionType.NAMESPACE_METADATA:
 			return CreateTransaction.namespaceMetadata(transactionObj);
 		case TransactionType.VOTING_KEY_LINK:
@@ -746,7 +756,7 @@ class TransactionService {
 			transactionDTO.type === TransactionType.AGGREGATE_COMPLETE
 		) {
 			const { mosaicInfos, mosaicNames, unresolvedMosaicsMap } =
-				await helper.getTransactionMosaicInfoAndNamespace(transactionDTO.innerTransactions);
+				await helper.getTransactionMosaicInfoAndNamespace(transactionDTO);
 
 			const innerTransactions = transactionDTO.innerTransactions
 				? await Promise.all(transactionDTO.innerTransactions.map(async (transaction, index) => {
@@ -783,7 +793,7 @@ class TransactionService {
 			};
 		} else {
 			const { mosaicInfos, mosaicNames, unresolvedMosaicsMap } =
-				await helper.getTransactionMosaicInfoAndNamespace([transactionDTO]);
+				await helper.getTransactionMosaicInfoAndNamespace(transactionDTO);
 
 			return this.createStandaloneTransactionFromSDK(transactionDTO, {
 				mosaicInfos,


### PR DESCRIPTION
## What was the issue?
- Mosaic alias expired, transaction page can not load the page.

## What's the fix?
- Added transactionLocation params in `resolveMosaicId` method.
- Implement mosaic resolution statement query in the `resolveMosaicId` method.
- Refactor `getTransactionMosaicInfoAndNamespace` method to process the transaction.
- Refactor `getMosaicInfoAndNamespace` method to accept mosaicID and transactionLocation params.
- Refactor affected transaction methods in CreateTransaction object such as `mosaicDefinition`, `mosaicSupplyChange`, `mosaicAddressRestriction`, and `mosaicMetadata`