### PR TITLE
[explorer] fix: remove database field in node status with non API roles 

### DIFF
--- a/__tests__/infrastructure/NodeService.spec.js
+++ b/__tests__/infrastructure/NodeService.spec.js
@@ -253,10 +253,11 @@ describe('Node Service', () => {
 
 				const expectedLightAPIStatus = {
 					...expectedAPIStatus,
-					apiNodeStatus: 'N/A',
+					lightNodeStatus: true,
 					connectionStatus: true
 				};
 				delete expectedLightAPIStatus.databaseStatus;
+				delete expectedLightAPIStatus.apiNodeStatus;
 
 				await assertNodeStatus(lightNodeResponse, {
 					peerStatus: expectedPeerStatus,

--- a/__tests__/infrastructure/NodeService.spec.js
+++ b/__tests__/infrastructure/NodeService.spec.js
@@ -238,6 +238,36 @@ describe('Node Service', () => {
 			});
 		});
 
+		const runLightRestNodeTests = roles => {
+			it(`returns roles ${roles} node status and light rest status`, async () => {
+				// Arrange:
+				const lightNodeResponse = {
+					roles,
+					peerStatus: generateNodePeerStatus(true),
+					apiStatus: {
+						...generateNodeApiStatus(true),
+						nodeStatus: undefined
+					},
+					...nodeCommonField
+				};
+
+				const expectedLightAPIStatus = {
+					...expectedAPIStatus,
+					apiNodeStatus: 'N/A',
+					connectionStatus: true
+				};
+				delete expectedLightAPIStatus.databaseStatus;
+
+				await assertNodeStatus(lightNodeResponse, {
+					peerStatus: expectedPeerStatus,
+					apiStatus: expectedLightAPIStatus,
+					chainInfo: expectedChainInfoStatus
+				});
+			});
+		};
+
+		[1, 4, 5].forEach(roles => runLightRestNodeTests(roles));
+
 		runStatisticServiceFailResponseTests('getNode', 'getNodeInfo');
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3510,9 +3510,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.3.tgz",
-      "integrity": "sha512-JEhMNwUJt7bw728CydvYzntD0XJeTmDnvwLlbfbAhE7Tbslm/ax6bdIiUwTgeVlZTsJQPwZwKpAkyDtIjsvx3g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.4.tgz",
+      "integrity": "sha512-5kz9ScmzBdzTgB/3susoCgfqNDzBjvLL4taparufgSvlwjdLy6UyUy9T/tCpYd2GIdIilCatC4iSQS0QSYHt0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8658,9 +8658,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
-      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8670,13 +8670,13 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+      "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.2"
+        "browserslist": "^4.24.3"
       },
       "funding": {
         "type": "opencollective",
@@ -10181,9 +10181,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.76",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
-      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "version": "1.5.79",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.79.tgz",
+      "integrity": "sha512-nYOxJNxQ9Om4EC88BE4pPoNI8xwSFf8pU/BAeOl4Hh/b/i6V4biTAzwV7pXi3ARKeoYO5JZKMIXTryXSVer5RA==",
       "license": "ISC"
     },
     "node_modules/elliptic": {

--- a/src/components/tables/TableView.vue
+++ b/src/components/tables/TableView.vue
@@ -233,7 +233,8 @@ export default {
                 'apiNodeStatus' === key ||
 				'databaseStatus' === key ||
 				'isHttpsEnabled' === key ||
-				'isAvailable' === key
+				'isAvailable' === key ||
+				'lightNodeStatus' === key
 			);
 		},
 

--- a/src/config/i18n/en-us.json
+++ b/src/config/i18n/en-us.json
@@ -350,6 +350,7 @@
     "connectionStatus": "Connection",
     "databaseStatus": "Data Base",
     "apiNodeStatus": "API Node",
+    "lightNodeStatus": "Light Node",
     "isAvailable": "Available",
     "lastStatusCheck": "Last Status Check",
     "nodeChainInfoTitle": "Node Chain Info",

--- a/src/config/i18n/es.json
+++ b/src/config/i18n/es.json
@@ -346,6 +346,7 @@
     "connectionStatus": "Connection",
     "databaseStatus": "Data Base",
     "apiNodeStatus": "API Node",
+    "lightNodeStatus": "Light Node",
     "isAvailable": "Available",
     "lastStatusCheck": "Last Status Check",
     "nodeChainInfoTitle": "Node Chain Info",

--- a/src/config/i18n/ja.json
+++ b/src/config/i18n/ja.json
@@ -350,6 +350,7 @@
     "connectionStatus": "接続",
     "databaseStatus": "データベース",
     "apiNodeStatus": "API ノード",
+    "lightNodeStatus": "Light ノード",
     "isAvailable": "有効",
     "lastStatusCheck": "最終チェック",
     "nodeChainInfoTitle": "ノードチェーン情報",

--- a/src/config/i18n/ko.json
+++ b/src/config/i18n/ko.json
@@ -350,6 +350,7 @@
     "connectionStatus": "연결",
     "databaseStatus": "데이터베이스",
     "apiNodeStatus": "API 노드",
+    "lightNodeStatus": "Light 노드",
     "isAvailable": "활성",
     "lastStatusCheck": "마지막 상태 확인",
     "nodeChainInfoTitle": "노드 체인 정보",

--- a/src/config/i18n/pt.json
+++ b/src/config/i18n/pt.json
@@ -347,6 +347,7 @@
     "connectionStatus": "Connection",
     "databaseStatus": "Data Base",
     "apiNodeStatus": "API Node",
+    "lightNodeStatus": "Light Node",
     "isAvailable": "Available",
     "lastStatusCheck": "Last Status Check",
     "nodeChainInfoTitle": "Node Chain Info",

--- a/src/config/i18n/ru.json
+++ b/src/config/i18n/ru.json
@@ -350,6 +350,7 @@
     "connectionStatus": "Соединение",
     "databaseStatus": "База данных",
     "apiNodeStatus": "API Ноды",
+    "lightNodeStatus": "Light Ноды",
     "isAvailable": "Доступные",
     "lastStatusCheck": "Последняя проверка статуса",
     "nodeChainInfoTitle": "Информация о цепочке нод",

--- a/src/config/i18n/ua.json
+++ b/src/config/i18n/ua.json
@@ -346,6 +346,7 @@
     "connectionStatus": "Connection",
     "databaseStatus": "Data Base",
     "apiNodeStatus": "API Node",
+    "lightNodeStatus": "Light Node",
     "isAvailable": "Available",
     "lastStatusCheck": "Last Status Check",
     "nodeChainInfoTitle": "Node Chain Info",

--- a/src/config/i18n/zh.json
+++ b/src/config/i18n/zh.json
@@ -346,6 +346,7 @@
     "connectionStatus": "Connection",
     "databaseStatus": "Data Base",
     "apiNodeStatus": "API Node",
+    "lightNodeStatus": "Light Node",
     "isAvailable": "Available",
     "lastStatusCheck": "Last Status Check",
     "nodeChainInfoTitle": "Node Chain Info",

--- a/src/config/pages/node-detail.json
+++ b/src/config/pages/node-detail.json
@@ -78,6 +78,7 @@
 					"connectionStatus",
 					"databaseStatus",
 					"apiNodeStatus",
+					"lightNodeStatus",
 					"isHttpsEnabled",
 					"restVersion",
 					"lastStatusCheck"

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -183,8 +183,6 @@ class NodeService {
 				// Api status
 				formattedNode.apiStatus = {
 					connectionStatus: isAvailable,
-					databaseStatus:
-						'up' === nodeStatus?.db || Constants.Message.UNAVAILABLE,
 					apiNodeStatus:
 						'up' === nodeStatus?.apiNode || Constants.Message.UNAVAILABLE,
 					isHttpsEnabled,
@@ -193,6 +191,14 @@ class NodeService {
 						.utc(lastStatusCheck)
 						.format('YYYY-MM-DD HH:mm:ss')
 				};
+
+				// Only API nodes have database status
+				if ([2, 3, 6, 7].includes(node.roles)) {
+					formattedNode.apiStatus = {
+						...formattedNode.apiStatus,
+						databaseStatus: 'up' === nodeStatus?.db || Constants.Message.UNAVAILABLE
+					};
+				}
 
 				// Chain info
 				formattedNode.chainInfo = {

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -201,9 +201,9 @@ class NodeService {
 				} else {
 					formattedNode.apiStatus = {
 						...formattedNode.apiStatus,
-						lightNodeStatus: isAvailable || Constants.Message.UNAVAILABLE,
+						lightNodeStatus: isAvailable || Constants.Message.UNAVAILABLE
 					};
-				}
+				};
 
 				// Chain info
 				formattedNode.chainInfo = {

--- a/src/infrastructure/NodeService.js
+++ b/src/infrastructure/NodeService.js
@@ -183,8 +183,6 @@ class NodeService {
 				// Api status
 				formattedNode.apiStatus = {
 					connectionStatus: isAvailable,
-					apiNodeStatus:
-						'up' === nodeStatus?.apiNode || Constants.Message.UNAVAILABLE,
 					isHttpsEnabled,
 					restVersion,
 					lastStatusCheck: moment
@@ -196,7 +194,14 @@ class NodeService {
 				if ([2, 3, 6, 7].includes(node.roles)) {
 					formattedNode.apiStatus = {
 						...formattedNode.apiStatus,
+						apiNodeStatus:
+							'up' === nodeStatus?.apiNode || Constants.Message.UNAVAILABLE,
 						databaseStatus: 'up' === nodeStatus?.db || Constants.Message.UNAVAILABLE
+					};
+				} else {
+					formattedNode.apiStatus = {
+						...formattedNode.apiStatus,
+						lightNodeStatus: isAvailable || Constants.Message.UNAVAILABLE,
 					};
 				}
 


### PR DESCRIPTION
problem: non-API roles display `Data Base` status in node status.
solution: check on the node roles, `Data Base` only displays node contain API roles.

Before:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/cb6a37fd-c346-4456-98a4-92a035da9836" />


After:
<img width="321" alt="image" src="https://github.com/user-attachments/assets/889d6659-d20f-4e1e-b54b-893dfab3f447" />

