### PR TITLE
[explorer] fix: handle mime empty string in header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "leaflet": "^1.8.0",
         "leaflet.markercluster": "^1.4.1",
         "merkletreejs": "^0.2.31",
+        "mime-types": "^2.1.35",
         "moment-timezone": "^0.5.35",
         "nem-sdk": "^1.6.8",
         "net": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.4.1",
     "merkletreejs": "^0.2.31",
+    "mime-types": "^2.1.35",
     "moment-timezone": "^0.5.35",
     "nem-sdk": "^1.6.8",
     "net": "^1.0.2",

--- a/vue.config.js
+++ b/vue.config.js
@@ -33,7 +33,6 @@ module.exports = {
 				path: require.resolve('path-browserify'),
 				vm: require.resolve('vm-browserify'),
 				fs: false,
-				vm: false,
 			}
 		},
 		plugins: [


### PR DESCRIPTION
problem: when server hosting a page, mime type repsonse empty string. it cause by after upgrade those dependencies.
solution: Handle mime type on the header reponse in server.