### PR TITLE
[explorer] fix: update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Licensed under the [Apache License 2.0](LICENSE)
 [self]: https://github.com/symbol/symbol-explorer
 [docs]: https://docs.symbolplatform.com
 [issues]: https://github.com/symbol/symbol-explorer/issues
-[discord]: https://discord.com/invite/xymcity
+[discord]: https://discord.gg/NMA9YQ55td

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -17,7 +17,7 @@
 				"icon": "IconGithub"
 			},
 			{
-				"href": "https://discord.com/invite/xymcity",
+				"href": "https://discord.gg/NMA9YQ55td",
 				"text": "Discord",
 				"icon": "IconDiscord"
 			},


### PR DESCRIPTION
Problem: The Discord link is outdated.
Solution: Updated the latest link.