### PR TITLE
[explorer] fix: statistic page bubble chart cut half

### DIFF
--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -220,7 +220,8 @@ export default {
 				tooltip: {
 					enabled: true,
 					z: {
-						title: 'Count: '
+						formatter: () => '',
+						title: ''
 					},
 				},
 				legend: {

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -88,6 +88,16 @@ export default {
 		intYaxis: {
 			type: Boolean,
 			default: false
+		},
+		// Axis range configuration for bubble charts
+		xaxisRange: {
+			type: Array,
+			default: () => null
+		},
+
+		yaxisRange: {
+			type: Array,
+			default: () => null
 		}
 	},
 
@@ -114,7 +124,13 @@ export default {
 							reset: '<i class="ico-ios-refresh-outline" style="font-size: 22px;"></i>',
 							customIcons: []
 						}
-					}
+					},
+					...(this.type === 'bubble' && {
+						zoom: {
+							enabled: false,
+							type: 'x'
+						},
+					})
 				},
 				stroke: {
 					show: true,
@@ -160,7 +176,7 @@ export default {
 					display: false
 				},
 				xaxis: {
-					type: this.xaxisType,
+					type: this.type === 'bubble' ? 'numeric' : this.xaxisType,
 					axisBorder: {
 						show: false,
 						color: '#0998a6'
@@ -173,7 +189,11 @@ export default {
 									: val;
 							}
 						}
-						: {}
+						: {},
+					...(this.xaxisRange && {
+						min: this.xaxisRange[0],
+						max: this.xaxisRange[1]
+					})
 				},
 				yaxis: {
 					tooltip: {
@@ -191,7 +211,11 @@ export default {
 									: val;
 							}
 						}
-						: {}
+						: {},
+					...(this.yaxisRange && {
+						min: this.yaxisRange[0],
+						max: this.yaxisRange[1]
+					})
 				},
 				tooltip: {
 					enabled: true,

--- a/src/components/widgets/NodeHeightAndFinalizedHeightStatsWidget.vue
+++ b/src/components/widgets/NodeHeightAndFinalizedHeightStatsWidget.vue
@@ -12,6 +12,8 @@
 						:data="chartData"
 						xaxisType="category"
 						:height="400"
+						:xaxisRange="xaxisRange"
+						:yaxisRange="yaxisRange"
 					/>
 				</b-col>
 			</b-row>
@@ -55,6 +57,43 @@ export default {
 
 		chartData () {
 			return this.data || [];
+		},
+
+		// Calculate axis ranges for bubble chart to ensure full circles
+		xaxisRange () {
+			if (!this.chartData || this.chartData.length === 0) return null;
+
+			const allXValues = [];
+			this.chartData.forEach(series => {
+				series.data.forEach(point => {
+					allXValues.push(point.x);
+				});
+			});
+
+			const minX = Math.min(...allXValues);
+			const maxX = Math.max(...allXValues);
+			const range = (maxX - minX) * 0.05;
+
+			// Add padding to ensure bubbles don't get cut off
+			return [minX - range, maxX + range];
+		},
+
+		yaxisRange () {
+			if (!this.chartData || this.chartData.length === 0) return null;
+
+			const allYValues = [];
+			this.chartData.forEach(series => {
+				series.data.forEach(point => {
+					allYValues.push(point.y);
+				});
+			});
+
+			const minY = Math.min(...allYValues);
+			const maxY = Math.max(...allYValues);
+			const range = (maxY - minY) * 0.5;
+
+			// Add padding to ensure bubbles don't get cut off
+			return [Math.max(0, minY - range), maxY + range];
 		},
 
 		loading () {


### PR DESCRIPTION
Problem: Bubble chart circle cut in half, tooltips display duplicate data.

<img width="87" height="193" alt="image" src="https://github.com/user-attachments/assets/457cd484-2bd6-4694-8a8f-4d2d9115d8e1" />

<img width="263" height="121" alt="image" src="https://github.com/user-attachments/assets/7be1fbe6-e519-43bd-9687-ac518517343b" />

Solution:  Extended X and Y axis range, removed duplicate Z value.

<img width="1246" height="546" alt="Screenshot 2025-08-30 at 4 48 36 AM" src="https://github.com/user-attachments/assets/85c6c0f7-3045-42cb-9efe-93ccb4d8077e" />
